### PR TITLE
docs: add market research and pitch deck outline

### DIFF
--- a/MARKET_RESEARCH.md
+++ b/MARKET_RESEARCH.md
@@ -1,0 +1,35 @@
+# Market Research & Feasibility Study
+
+## 1. Break-Even Analysis
+- **Per-seat SaaS**: $20/user/mo -> ~3,200 users to cover $600k/yr costs.
+- **API usage**: $0.01/doc with 80% margin -> ~50M docs/yr.
+- **Enterprise flat fee**: $100k–250k/yr -> 3–6 clients.
+
+## 2. Market Sizing
+- **Healthcare**: HIPAA compliance market $6.5B by 2030; initial SOM $5–10M.
+- **Financial Services**: PCI compliance ~$7.9B by 2032; early SOM ~$5M.
+- **General Enterprise**: Privacy software $30B by 2030; 1% share could reach $100M.
+
+## 3. Competitive Landscape
+- **Nightfall AI**: Browser extension DLP, enterprise focused.
+- **OneTrust**: Broad privacy platform, admin heavy.
+- **BigID**: Data discovery/governance with AI labeling.
+- **Specialized startups**: Sentra, Strac, Private AI, etc.
+- Opportunity for user-friendly, cross-platform "Grammarly-like" UX.
+
+## 4. Business Model & GTM
+- **Freemium**: Free tier drives viral adoption.
+- **Team/Enterprise tiers**: $15–30/user/mo; $50k–250k/yr flat fees.
+- **Channels**: Direct product-led growth, security resellers, tech alliances.
+
+## 5. Financial Projections (Years 1–2)
+| Year | Revenue | COGS (20%) | OpEx (R&D/S&M/G&A) | Operating Loss |
+|------|---------|------------|---------------------|----------------|
+| 1    | $50k    | $10k       | $350k               | -$310k         |
+| 2    | $300k   | $60k       | $600k               | -$360k         |
+
+## 6. Investor Perspective
+- Strong VC appetite for AI privacy tools.
+- Comparable startups (e.g., Delve, Freshpaint) raised $30M+.
+- Positioning: "Seatbelt" enabling safe enterprise AI adoption.
+

--- a/PITCH_DECK.md
+++ b/PITCH_DECK.md
@@ -1,0 +1,52 @@
+# Pitch Deck Outline — Shadow AI Guard
+
+1. **Title**
+   - Tagline: "The seatbelt for enterprise AI adoption."
+   - Team: Zach (CTO), Mark (CPO), Chris (COO), Bobby (CRO/BD).
+
+2. **Problem**
+   - Employees paste sensitive data into AI tools.
+   - 63% of ChatGPT inputs contain PII; firms ban AI over leaks.
+
+3. **Market**
+   - Privacy/DLP $21B by 2034; privacy software $30B by 2030.
+   - Target U.S. SAM ~$5–10B; early SOM ~$5M.
+
+4. **Current Solutions Fail**
+   - Legacy DLP: heavy, not real-time.
+   - OneTrust/BigID: admin-focused.
+   - DIY bans hurt productivity.
+
+5. **Our Solution**
+   - Browser extension + API middleware.
+   - Highlights & redacts PII/PHI/PCI before prompts leave.
+   - Compliance dashboard & audit logs.
+
+6. **Demo**
+   - Before/after prompt redaction.
+   - Dashboard with incident reports.
+
+7. **Business Model**
+   - Freemium; Pro $15–30/user/mo; Enterprise $50k–250k/yr.
+   - API usage: $0.01–0.05 per document.
+
+8. **Traction & Roadmap**
+   - Q4 2025: Beta with 1k installs.
+   - Q2 2026: Paid Teams & 5 pilots.
+   - 2027: 100 enterprise clients, $5M ARR.
+
+9. **Competitive Landscape**
+   - Nightfall, Sentra, Strac, OneTrust, BigID.
+   - Differentiator: Grammarly-like UX + viral adoption.
+
+10. **Financials**
+    - Year1 rev $50k, Year2 $300k, gross margin ~80%.
+
+11. **Team**
+    - Expertise in AI, UX, operations, and GTM.
+
+12. **Ask**
+    - Raising $1.5M seed for 18–24 months runway.
+    - Goal: 5k+ users, 10 enterprise clients.
+    - Vision: default AI guardrail.
+

--- a/README.md
+++ b/README.md
@@ -1,70 +1,53 @@
-# SGAI — SafeguardAI  
+# SGAI — SafeguardAI
 _The seatbelt for enterprise AI adoption._
 
-SafeguardAI (SGAI) is a **Grammarly-style compliance layer** that prevents sensitive data leaks into AI tools.  
-It detects and redacts **PII, PHI, and PCI data** in real time — before prompts leave the organization — enabling safe AI adoption under **HIPAA, PCI, GDPR, and CCPA**.
+SafeguardAI (SGAI) is a **Grammarly-style compliance layer** that detects and redacts **PII, PHI, and PCI data** in real time before prompts leave the organization, enabling safe AI adoption under **HIPAA, PCI, GDPR, and CCPA**.
 
 ---
 
 ## 🚀 Features
-
-- **Browser Extension (MV3)**  
-  Works across ChatGPT, Claude, Copilot, Gmail, Slack, Salesforce, etc.  
-  Inline highlights + suggestions, not just silent blocking.
-
-- **Interactive Demo**  
-  Redacts SSNs, credit cards, emails, DOBs, and more in real time.  
-  Hover highlights explain _why_ something was flagged.
-
-- **Compliance Dashboard**  
-  - 📊 KPIs (Incidents, Blocked %, Masked %, Top Entities)  
-  - 🔎 Incident drill-down with raw vs. sanitized payloads  
-  - ⚖️ Policy builder: visual IF/THEN rules (block, mask, approve, audit)  
-  - ✅ Approval workflows + audit logs
-
-- **Sector-Specific Landing Pages**  
-  Tailored messaging for **Healthcare (HIPAA/PHI)**, **Finance (PCI/GLBA/PII)**, and **General Enterprise (GDPR/CCPA)**.
-
-- **Pricing & ROI Calculator**  
-  Shows per-seat SaaS ($15–30/user), enterprise flat fee ($50k–250k/yr), and API usage ($0.01–0.05/doc).  
-  ROI demo estimates breach costs avoided.
+- **Browser Extension (MV3)**: Works across ChatGPT, Claude, Copilot, Gmail, Slack, Salesforce, etc., with inline highlights and suggestions.
+- **Interactive Demo**: Redacts SSNs, credit cards, emails, and DOBs in real time with hover explanations.
+- **Compliance Dashboard**:
+  - 📊 KPIs (incidents, blocked %, masked %, top entities)
+  - 🔎 Incident drill-down with raw vs. sanitized payloads
+  - ⚖️ Policy builder (visual IF/THEN rules)
+  - ✅ Approval workflows and audit logs
+- **Sector-Specific Messaging**: Tailored pages for Healthcare, Finance, and Enterprise.
+- **Pricing & ROI Calculator**: Per-seat SaaS ($15–30/user), enterprise flat fee ($50k–250k/yr), and API usage ($0.01–0.05/doc) with breach cost estimates.
 
 ---
 
 ## 🏗 Tech Stack
-
-- [Next.js 14 (App Router)](https://nextjs.org/) + [TypeScript](https://www.typescriptlang.org/)  
-- [Tailwind CSS](https://tailwindcss.com/) + [shadcn/ui](https://ui.shadcn.com/) + [Framer Motion](https://www.framer.com/motion/)  
-- [Zustand](https://zustand-demo.pmnd.rs/) for state, [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) for forms/validation  
-- [Lucide Icons](https://lucide.dev/) for UI  
-- [Vitest](https://vitest.dev/) for unit tests, [Playwright](https://playwright.dev/) for E2E smoke tests  
-- [Chrome Extension MV3](https://developer.chrome.com/docs/extensions/) with shared React components
+- Next.js 14 (App Router) + TypeScript
+- Tailwind CSS + shadcn/ui + Framer Motion
+- Zustand state, React Hook Form + Zod validation
+- Lucide Icons
+- Vitest unit tests, Playwright E2E tests
+- Chrome Extension MV3 with shared React components
 
 ---
 
-## 📂 Project Structure (high level)
-
+## 📂 Project Structure
+```
 /app
-/(marketing)/[icp] -> Healthcare, Finance, Enterprise
+/(marketing)/[icp]
 /(marketing)/install
 /(marketing)/pricing
 /(marketing)/roi
 /(demo)/demo
 /(console)/{dashboard,policies,approvals,settings}
-/components -> UI + feature components
-/data -> mock JSON for incidents, policies, pricing
-/lib -> detectors, policies, mock API
-/store -> Zustand stores
-/extension -> Chrome MV3 (popup, options, content script)
-/tests -> Playwright + Vitest
-
-yaml
-Copy code
+/components
+/data
+/lib
+/store
+/extension
+/tests
+```
 
 ---
 
 ## 🧪 Local Development
-
 ```bash
 # Install deps
 npm install
@@ -72,93 +55,62 @@ npm install
 # Start dev server
 npm run dev
 
-# Run unit tests (Vitest)
-npm run test
+# Run unit tests
+npm test
 
-# Run E2E tests (Playwright)
+# Run E2E tests
 npx playwright test
+
+# Build production app
+npm run build
 
 # Build Chrome extension (outputs to /extension/dist)
 npm run build:ext
-Then load the extension in Chrome:
+```
+Load the extension in Chrome by enabling Developer Mode at `chrome://extensions` and selecting `extension/dist`.
 
-Go to chrome://extensions/
+### Mock Data & APIs
+- `/data/*.json` seeds incidents, policies, pricing, and ROI assumptions.
+- Mock API routes under `/api/mock/*`.
+- Demo redaction runs locally in-browser; no data leaves the device.
 
-Enable Developer Mode
+---
 
-Click Load unpacked → select /extension/dist
+## 📊 Market Positioning
+SGAI addresses the "Shadow AI" risk where employees unknowingly leak sensitive data into LLMs.
 
-🎯 Mock Data & APIs
-All data is seeded locally in /data/*.json and surfaced via mock API routes (/api/mock/*).
-This enables full demo functionality without backend dependencies.
+- 63% of ChatGPT inputs contain PII.
+- Companies like Samsung, Amazon, and Apple have banned AI tools over data leaks.
+- Regulators (HIPAA, PCI, GDPR) impose multi-million-dollar fines.
 
-incidents.json → populates dashboard
+**Differentiators**
+- Employee-friendly UX (Grammarly-like highlights)
+- Bottom-up freemium adoption
+- Enterprise compliance depth (audit logs, SSO/SCIM, on-prem options)
 
-policies.json → powers policy builder
+---
 
-pricing.json → drives pricing calculator
+## 🗺 Further Reading
+- [Market Research & Feasibility Study](MARKET_RESEARCH.md)
+- [Pitch Deck Outline](PITCH_DECK.md)
 
-roiAssumptions.json → breach costs for ROI tool
+---
 
-🛡 Privacy & Security (Demo Mode)
-All demo redaction runs locally in-browser (regex + simple NER stubs).
+## 👥 Team
+- Zach — CTO (AI/ML, full-stack engineering)
+- Mark — CPO (UX/product design)
+- Chris — COO (operations & compliance)
+- Bobby — CRO/BD (GTM & partnerships)
 
-No data is stored or transmitted externally.
+---
 
-Enterprise mode will support on-prem and API proxy deployment for compliance.
+## 📜 License
+MIT (subject to change as enterprise features mature)
 
-📊 Market Positioning
-SGAI addresses the urgent “Shadow AI” problem:
+## 🤝 Contributing
+We welcome PRs for new detectors, UI/UX polish, and tests.
 
-63% of ChatGPT inputs contain PII
-
-Samsung, Amazon, Apple banned AI tools due to leaks
-
-Regulators (HIPAA, PCI, GDPR) impose multi-million-dollar fines
-
-Differentiation
-Employee-friendly UX (Grammarly-like assistive highlights)
-
-Bottom-up freemium adoption → viral growth inside orgs
-
-Enterprise compliance depth (audit logs, SSO/SCIM, on-prem options)
-
-Target ICPs
-🏥 Healthcare (HIPAA/PHI redaction)
-
-💳 Finance (PCI/GLBA, credit cards, account numbers)
-
-🏢 Enterprise (GDPR/CCPA, DSAR redaction, general privacy)
-
-📈 Roadmap (Draft)
-Q4 2025: Chrome Extension Beta, 1k free installs
-
-Q2 2026: Paid Teams launch, 5 enterprise pilots
-
-2027: 100 enterprise clients, $5M ARR
-
-👥 Team
-Zach — CTO (AI/ML, full-stack engineering)
-
-Mark — CPO (UX/product design)
-
-Chris — COO (Ops, compliance, enterprise process)
-
-Bobby — CRO/BD (Networking, partnerships, GTM)
-
-📜 License
-MIT (for now, subject to change as we productize enterprise features)
-
-🤝 Contributing
-We welcome PRs for:
-
-New detectors (regex/ML models for PII/PHI/PCI)
-
-UI/UX polish
-
-Tests (Vitest/Playwright coverage)
-
-📬 Contact
+## 📬 Contact
 Website: safeguardai.dev (placeholder)
 
 Email: founders@safeguardai.dev


### PR DESCRIPTION
## Summary
- clean up README with local build/test instructions and links
- add condensed market research and pitch deck outline docs

## Testing
- `npm test`
- `npx playwright test` *(fails: browserType.launch: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68b23cfa8634832380abdcd98c2c6fbf