### PR TITLE
Add standalone redaction playground

### DIFF
--- a/app/(demo2)/playground2/page.tsx
+++ b/app/(demo2)/playground2/page.tsx
@@ -1,0 +1,14 @@
+import samples from '@/data/demo2/samples.json';
+import BeforeAfter2 from '@/components/demo2/BeforeAfter2';
+import LocalDetectorsPane from '@/components/demo2/LocalDetectorsPane';
+import '@/styles/demo2.css';
+
+export default function Playground2Page() {
+  return (
+    <section className="p-8 space-y-6">
+      <h1 className="text-3xl font-bold">Redaction Playground</h1>
+      <LocalDetectorsPane />
+      <BeforeAfter2 samples={samples.samples} />
+    </section>
+  );
+}

--- a/app/api/demo2/scan/route.ts
+++ b/app/api/demo2/scan/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+type Match = {
+  type: string;
+  match: string;
+  index: number;
+  severity: 'high' | 'medium' | 'low';
+  suggestion: string;
+};
+
+function luhnCheck(num: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+  for (let i = num.length - 1; i >= 0; i--) {
+    let digit = parseInt(num.charAt(i), 10);
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    shouldDouble = !shouldDouble;
+  }
+  return sum % 10 === 0;
+}
+
+export async function POST(req: NextRequest) {
+  const { text } = await req.json();
+  const matches: Match[] = [];
+
+  const emailRegex = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+  const ssnRegex = /\b\d{3}-\d{2}-\d{4}\b/g;
+  const ccRegex = /\b(?:\d[ -]*?){13,16}\b/g;
+
+  for (const m of text.matchAll(emailRegex)) {
+    matches.push({
+      type: 'Email',
+      match: m[0],
+      index: m.index || 0,
+      severity: 'medium',
+      suggestion: 'Remove email addresses',
+    });
+  }
+  for (const m of text.matchAll(ssnRegex)) {
+    matches.push({
+      type: 'SSN',
+      match: m[0],
+      index: m.index || 0,
+      severity: 'high',
+      suggestion: 'Do not share SSNs',
+    });
+  }
+  for (const m of text.matchAll(ccRegex)) {
+    const digits = m[0].replace(/[ -]/g, '');
+    if (luhnCheck(digits)) {
+      matches.push({
+        type: 'Credit Card',
+        match: m[0],
+        index: m.index || 0,
+        severity: 'high',
+        suggestion: 'Remove credit card numbers',
+      });
+    }
+  }
+
+  let redacted = text;
+  matches
+    .sort((a, b) => b.index - a.index)
+    .forEach((m) => {
+      redacted =
+        redacted.slice(0, m.index) +
+        '[REDACTED]' +
+        redacted.slice(m.index + m.match.length);
+    });
+
+  return NextResponse.json({ redacted, matches });
+}

--- a/components/demo2/BeforeAfter2.tsx
+++ b/components/demo2/BeforeAfter2.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { useState } from 'react';
+import InlineCoachBadge from './InlineCoachBadge';
+
+type Match = {
+  type: string;
+  match: string;
+  severity: 'high' | 'medium' | 'low';
+  suggestion: string;
+};
+
+export default function BeforeAfter2({ samples }: { samples: string[] }) {
+  const [input, setInput] = useState(samples[0] || '');
+  const [redacted, setRedacted] = useState('');
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function handleScan() {
+    setLoading(true);
+    const res = await fetch('/api/demo2/scan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: input }),
+    });
+    const data = await res.json();
+    setRedacted(data.redacted);
+    setMatches(data.matches);
+    setLoading(false);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="mr-2 text-sm">Sample:</label>
+        <select
+          className="border p-1 text-sm"
+          onChange={(e) => setInput(e.target.value)}
+        >
+          {samples.map((s, i) => (
+            <option key={i} value={s}>
+              Sample {i + 1}
+            </option>
+          ))}
+        </select>
+      </div>
+      <textarea
+        className="w-full border p-2 h-40"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <button
+        className="px-3 py-1 bg-blue-500 text-white rounded"
+        onClick={handleScan}
+        disabled={loading}
+      >
+        {loading ? 'Scanning...' : 'Scan'}
+      </button>
+      {redacted && (
+        <div className="p-4 border rounded">
+          <h3 className="font-semibold mb-2">Redacted</h3>
+          <p className="whitespace-pre-wrap">{redacted}</p>
+          <InlineCoachBadge matches={matches} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/demo2/InlineCoachBadge.tsx
+++ b/components/demo2/InlineCoachBadge.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useState } from 'react';
+
+type Match = {
+  type: string;
+  match: string;
+  severity: 'high' | 'medium' | 'low';
+  suggestion: string;
+};
+
+export default function InlineCoachBadge({ matches }: { matches: Match[] }) {
+  const [open, setOpen] = useState(false);
+  const counts = matches.reduce<Record<string, number>>((acc, m) => {
+    acc[m.severity] = (acc[m.severity] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="mt-2">
+      <button
+        className="flex items-center gap-2 text-sm underline"
+        onClick={() => setOpen(true)}
+      >
+        <span>Issues:</span>
+        {['high', 'medium', 'low'].map((s) =>
+          counts[s] ? (
+            <span key={s} className={`badge-${s}`}>{counts[s]}</span>
+          ) : null,
+        )}
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/40 flex items-center justify-center"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-white p-4 rounded shadow max-w-md w-full"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-semibold mb-2">Detected Issues</h3>
+            <ul className="space-y-2 max-h-60 overflow-y-auto">
+              {matches.map((m, i) => (
+                <li key={i} className="text-sm">
+                  <strong>{m.type}:</strong> {m.match} – {m.suggestion}
+                </li>
+              ))}
+            </ul>
+            <button
+              className="mt-4 px-3 py-1 bg-blue-500 text-white rounded"
+              onClick={() => setOpen(false)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/demo2/LocalDetectorsPane.tsx
+++ b/components/demo2/LocalDetectorsPane.tsx
@@ -1,0 +1,12 @@
+export default function LocalDetectorsPane() {
+  return (
+    <div className="p-4 border rounded">
+      <h2 className="mb-2 font-semibold">Local Detectors</h2>
+      <ul className="list-disc pl-5 space-y-1 text-sm">
+        <li>Email addresses</li>
+        <li>US Social Security numbers</li>
+        <li>Credit card numbers (Luhn validated)</li>
+      </ul>
+    </div>
+  );
+}

--- a/data/demo2/samples.json
+++ b/data/demo2/samples.json
@@ -1,0 +1,7 @@
+{
+  "samples": [
+    "Contact me at investor@example.com to discuss funding opportunities.",
+    "Jane Smith's SSN is 987-65-4320 and her phone is 555-123-4567.",
+    "Charge my card 4242 4242 4242 4242 for the prototype purchase."
+  ]
+}

--- a/styles/demo2.css
+++ b/styles/demo2.css
@@ -1,0 +1,18 @@
+.badge-high {
+  background: #ef4444;
+  color: white;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
+}
+.badge-medium {
+  background: #f59e0b;
+  color: white;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
+}
+.badge-low {
+  background: #10b981;
+  color: white;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- add `/playground2` demo with before/after editor and sample dropdown
- implement local PII detectors and scanning API
- include inline coaching badge with severity counts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23f5b0cb48323a670ab5ef4fad6e7