### PR TITLE
Add standalone pricing page with tiered plans

### DIFF
--- a/app/(marketing2)/pricing2/page.tsx
+++ b/app/(marketing2)/pricing2/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import PlanCardsV2 from '@/components/pricing2/PlanCardsV2';
+
+const faqs = [
+  {
+    question: 'Can I switch plans later?',
+    answer: 'Yes, you can upgrade or downgrade at any time. Billing updates on your next cycle.'
+  },
+  {
+    question: 'Do you offer discounts for annual billing?',
+    answer: 'Annual billing is simply the monthly price multiplied by 12.'
+  },
+  {
+    question: 'Is there an API trial?',
+    answer: 'API access is granted upon request and includes a 30-day trial.'
+  }
+];
+
+export default function PricingPageV2() {
+  const [open, setOpen] = useState<number | null>(null);
+
+  const toggle = (idx: number) => {
+    setOpen(open === idx ? null : idx);
+  };
+
+  return (
+    <section className="p-8 max-w-5xl mx-auto">
+      <h1 className="text-4xl font-bold text-center mb-10">Pricing</h1>
+      <PlanCardsV2 />
+      <div className="mt-16">
+        <h2 className="text-2xl font-semibold mb-4 text-center">FAQ</h2>
+        <div className="space-y-2">
+          {faqs.map((faq, idx) => (
+            <div key={faq.question} className="border-b">
+              <button
+                className="w-full text-left flex justify-between items-center py-4"
+                onClick={() => toggle(idx)}
+              >
+                <span className="font-medium">{faq.question}</span>
+                <span>{open === idx ? '-' : '+'}</span>
+              </button>
+              {open === idx && (
+                <p className="pb-4 text-sm text-gray-700">{faq.answer}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/pricing2/PlanCardsV2.tsx
+++ b/components/pricing2/PlanCardsV2.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import pricing from '@/data/pricing_v2.json';
+
+type Plan = {
+  name: string;
+  price: number;
+  features: string[];
+};
+
+type Billing = 'monthly' | 'yearly';
+
+export default function PlanCardsV2() {
+  const [billing, setBilling] = useState<Billing>('monthly');
+  const [activePlan, setActivePlan] = useState<string | null>(null);
+
+  const priceFor = (plan: Plan) => {
+    return billing === 'monthly' ? plan.price : plan.price * 12;
+  };
+
+  return (
+    <div>
+      <div className="flex justify-center mb-8 space-x-4">
+        <button
+          className={`px-4 py-2 border rounded ${billing === 'monthly' ? 'bg-black text-white' : ''}`}
+          onClick={() => setBilling('monthly')}
+        >
+          Monthly
+        </button>
+        <button
+          className={`px-4 py-2 border rounded ${billing === 'yearly' ? 'bg-black text-white' : ''}`}
+          onClick={() => setBilling('yearly')}
+        >
+          Yearly
+        </button>
+      </div>
+      <div className="grid gap-6 md:grid-cols-4">
+        {pricing.plans.map((plan: Plan) => (
+          <div key={plan.name} className="border rounded p-6 flex flex-col">
+            <h3 className="text-xl font-semibold mb-2">{plan.name}</h3>
+            <p className="text-3xl font-bold mb-4">
+              ${priceFor(plan)}
+              <span className="text-sm font-normal text-gray-500">/{billing === 'monthly' ? 'mo' : 'yr'}</span>
+            </p>
+            <ul className="flex-1 mb-6 space-y-2">
+              {plan.features.map((f) => (
+                <li key={f} className="text-sm">{f}</li>
+              ))}
+            </ul>
+            <button
+              onClick={() => setActivePlan(plan.name)}
+              className="mt-auto w-full bg-black text-white py-2 rounded"
+            >
+              Request Access
+            </button>
+          </div>
+        ))}
+      </div>
+      {activePlan && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white p-6 rounded max-w-sm w-full">
+            <h3 className="text-lg font-semibold mb-2">Request Access</h3>
+            <p className="mb-4 text-sm">
+              We will reach out about the {activePlan} plan shortly.
+            </p>
+            <button
+              onClick={() => setActivePlan(null)}
+              className="w-full bg-black text-white py-2 rounded"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/data/pricing_v2.json
+++ b/data/pricing_v2.json
@@ -1,0 +1,39 @@
+{
+  "plans": [
+    {
+      "name": "Free",
+      "price": 0,
+      "features": [
+        "Basic market snapshots",
+        "Community support"
+      ]
+    },
+    {
+      "name": "Team",
+      "price": 49,
+      "features": [
+        "Unlimited searches",
+        "Team dashboards",
+        "Email support"
+      ]
+    },
+    {
+      "name": "Enterprise",
+      "price": 199,
+      "features": [
+        "Custom insights",
+        "SSO & advanced permissions",
+        "Dedicated success manager"
+      ]
+    },
+    {
+      "name": "API",
+      "price": 499,
+      "features": [
+        "Full API access",
+        "Usage analytics",
+        "Priority support"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement isolated pricing page with PlanCardsV2 and FAQ accordion
- add pricing_v2 dataset for Free, Team, Enterprise, and API plans
- include monthly/yearly toggle and Request Access modal for each tier

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23f67742883238e688aaaadaf9b4f