### PR TITLE
feat: add trust center pages

### DIFF
--- a/app/(trust2)/trust2/compliance/page.tsx
+++ b/app/(trust2)/trust2/compliance/page.tsx
@@ -1,0 +1,17 @@
+import controls from "@/data/trust2/controls.json";
+
+export default function CompliancePage() {
+  return (
+    <section className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Compliance</h1>
+      <ul className="list-disc ml-6 text-sm space-y-2">
+        {controls.map((control) => (
+          <li key={control.id}>
+            {control.id}: {control.description}
+          </li>
+        ))}
+        <li>24h detection / 72h response incident policy</li>
+      </ul>
+    </section>
+  );
+}

--- a/app/(trust2)/trust2/page.tsx
+++ b/app/(trust2)/trust2/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function TrustCenterPage() {
+  return (
+    <section className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Trust Center</h1>
+      <p className="text-sm mb-4">Transparency on our security, privacy, and compliance practices.</p>
+      <ul className="list-disc ml-6 text-sm space-y-2">
+        <li><Link href="/trust2/security" className="underline">Security</Link></li>
+        <li><Link href="/trust2/privacy" className="underline">Privacy</Link></li>
+        <li><Link href="/trust2/compliance" className="underline">Compliance</Link></li>
+      </ul>
+    </section>
+  );
+}

--- a/app/(trust2)/trust2/privacy/page.tsx
+++ b/app/(trust2)/trust2/privacy/page.tsx
@@ -1,0 +1,12 @@
+export default function PrivacyPage() {
+  return (
+    <section className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Privacy</h1>
+      <ul className="list-disc ml-6 text-sm space-y-2">
+        <li>Local-first data processing</li>
+        <li>Zero data retention</li>
+        <li>All information is hashed</li>
+      </ul>
+    </section>
+  );
+}

--- a/app/(trust2)/trust2/security/page.tsx
+++ b/app/(trust2)/trust2/security/page.tsx
@@ -1,0 +1,12 @@
+export default function SecurityPage() {
+  return (
+    <section className="p-8">
+      <h1 className="text-3xl font-bold mb-4">Security</h1>
+      <ul className="list-disc ml-6 text-sm space-y-2">
+        <li>Local-first threat detection</li>
+        <li>All data hashed at rest and in transit</li>
+        <li>24h detection / 72h response incident policy</li>
+      </ul>
+    </section>
+  );
+}

--- a/data/trust2/controls.json
+++ b/data/trust2/controls.json
@@ -1,0 +1,5 @@
+[
+  { "id": "CC1.1", "description": "Control environment established and maintained" },
+  { "id": "CC1.2", "description": "Board of directors exercises oversight" },
+  { "id": "CC2.1", "description": "Management establishes structure, reporting lines" }
+]


### PR DESCRIPTION
## Summary
- add new Trust Center with overview page and links to Security, Privacy, and Compliance subpages
- document SOC2 controls and incident response targets
- introduce security and privacy practices like local-first processing and zero retention

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23f7460548323a3b13400522df176