### PR TITLE
feat: add policy sandbox

### DIFF
--- a/app/(console2)/console-sandbox2/page.tsx
+++ b/app/(console2)/console-sandbox2/page.tsx
@@ -1,0 +1,12 @@
+import RuleDesigner from '@/components/policy2/RuleDesigner';
+import PolicyPreview from '@/components/policy2/PolicyPreview';
+
+export default function ConsoleSandbox2Page() {
+  return (
+    <section className="p-8 space-y-8">
+      <h1 className="text-2xl font-bold">Policy Sandbox 2</h1>
+      <RuleDesigner />
+      <PolicyPreview />
+    </section>
+  );
+}

--- a/components/policy2/PolicyPreview.tsx
+++ b/components/policy2/PolicyPreview.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Rule, evaluate, loadRules } from '@/lib/policy2';
+import samples from '@/data/policy2/samples.json';
+
+export default function PolicyPreview() {
+  const [text, setText] = useState(samples.sample);
+  const [rules, setRules] = useState<Rule[]>([]);
+  const [result, setResult] = useState(() => evaluate(samples.sample, []));
+  const [showMask, setShowMask] = useState(false);
+
+  useEffect(() => {
+    const update = () => setRules(loadRules());
+    update();
+    window.addEventListener('policy2:rules', update);
+    return () => window.removeEventListener('policy2:rules', update);
+  }, []);
+
+  useEffect(() => {
+    setResult(evaluate(text, rules));
+  }, [text, rules]);
+
+  return (
+    <div className="p-4 border rounded space-y-4 text-sm">
+      <textarea
+        className="w-full border p-2 h-40"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button
+        className="px-2 py-1 border rounded text-xs"
+        onClick={() => setShowMask((v) => !v)}
+      >
+        {showMask ? 'Show Raw' : 'Mask Preview'}
+      </button>
+      <pre className="bg-gray-50 p-2 rounded overflow-auto">{showMask ? result.masked : text}</pre>
+      <div>
+        <h3 className="font-semibold mb-1">Violations</h3>
+        {result.violations.length === 0 && (
+          <div className="text-gray-500">None</div>
+        )}
+        <ul className="space-y-1">
+          {result.violations.map((v) => (
+            <li key={v.rule.id} className="text-xs">
+              {v.rule.matcher} ({v.rule.action}): {v.matches.join(', ')}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/components/policy2/RuleDesigner.tsx
+++ b/components/policy2/RuleDesigner.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Rule, loadRules, saveRules } from '@/lib/policy2';
+
+const EMPTY: Rule = {
+  id: '',
+  scope: { org: '', domain: '', urlPattern: '' },
+  matcher: 'email',
+  customRegex: '',
+  action: 'mask',
+  severity: 'low',
+  explain: '',
+};
+
+export default function RuleDesigner() {
+  const [rules, setRules] = useState<Rule[]>([]);
+  const [editing, setEditing] = useState<Rule | null>(null);
+
+  useEffect(() => {
+    setRules(loadRules());
+  }, []);
+
+  useEffect(() => {
+    saveRules(rules);
+  }, [rules]);
+
+  const startEdit = (rule?: Rule) => {
+    if (rule) setEditing({ ...rule });
+    else setEditing({ ...EMPTY, id: Date.now().toString() });
+  };
+
+  const submit = () => {
+    if (!editing) return;
+    setRules((prev) => {
+      const exists = prev.some((r) => r.id === editing.id);
+      return exists ? prev.map((r) => (r.id === editing.id ? editing : r)) : [...prev, editing];
+    });
+    setEditing(null);
+  };
+
+  const remove = (id: string) => setRules((prev) => prev.filter((r) => r.id !== id));
+
+  return (
+    <div className="p-4 border rounded space-y-4 text-sm">
+      <div className="flex justify-between items-center">
+        <h2 className="font-semibold">Rules</h2>
+        <button className="px-2 py-1 border rounded text-xs" onClick={() => startEdit()}>Add</button>
+      </div>
+      {rules.length === 0 && <div className="text-gray-500">No rules defined.</div>}
+      <ul className="space-y-2">
+        {rules.map((r) => (
+          <li key={r.id} className="flex justify-between items-center border p-2 rounded">
+            <div>
+              <div className="font-medium">{r.matcher} → {r.action}</div>
+              <div className="text-xs text-gray-500">{r.explain}</div>
+            </div>
+            <div className="space-x-2 text-xs">
+              <button className="px-2 py-1 border rounded" onClick={() => startEdit(r)}>Edit</button>
+              <button className="px-2 py-1 border rounded" onClick={() => remove(r.id)}>Delete</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {editing && (
+        <div className="border-t pt-4 space-y-2">
+          <div className="grid grid-cols-3 gap-2">
+            <input
+              className="border p-1"
+              placeholder="Org"
+              value={editing.scope.org}
+              onChange={(e) => setEditing({ ...editing, scope: { ...editing.scope, org: e.target.value } })}
+            />
+            <input
+              className="border p-1"
+              placeholder="Domain"
+              value={editing.scope.domain}
+              onChange={(e) => setEditing({ ...editing, scope: { ...editing.scope, domain: e.target.value } })}
+            />
+            <input
+              className="border p-1"
+              placeholder="URL Pattern"
+              value={editing.scope.urlPattern}
+              onChange={(e) => setEditing({ ...editing, scope: { ...editing.scope, urlPattern: e.target.value } })}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <select
+              className="border p-1"
+              value={editing.matcher}
+              onChange={(e) => setEditing({ ...editing, matcher: e.target.value as any })}
+            >
+              <option value="email">email</option>
+              <option value="ssn">ssn</option>
+              <option value="cc">cc</option>
+              <option value="custom">custom</option>
+            </select>
+            {editing.matcher === 'custom' && (
+              <input
+                className="border p-1"
+                placeholder="Custom Regex"
+                value={editing.customRegex}
+                onChange={(e) => setEditing({ ...editing, customRegex: e.target.value })}
+              />
+            )}
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <select
+              className="border p-1"
+              value={editing.action}
+              onChange={(e) => setEditing({ ...editing, action: e.target.value as any })}
+            >
+              <option value="block">block</option>
+              <option value="mask">mask</option>
+              <option value="allow">allow</option>
+            </select>
+            <select
+              className="border p-1"
+              value={editing.severity}
+              onChange={(e) => setEditing({ ...editing, severity: e.target.value as any })}
+            >
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+            </select>
+            <input
+              className="border p-1 col-span-3 sm:col-span-1"
+              placeholder="Explain"
+              value={editing.explain}
+              onChange={(e) => setEditing({ ...editing, explain: e.target.value })}
+            />
+          </div>
+          <div className="space-x-2">
+            <button className="px-2 py-1 border rounded text-xs" onClick={submit}>Save</button>
+            <button className="px-2 py-1 border rounded text-xs" onClick={() => setEditing(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/data/policy2/samples.json
+++ b/data/policy2/samples.json
@@ -1,0 +1,3 @@
+{
+  "sample": "Contact us at support@example.com or 123-45-6789. Use card 4111-1111-1111-1111 for testing."
+}

--- a/lib/policy2.ts
+++ b/lib/policy2.ts
@@ -1,0 +1,71 @@
+export type Scope = {
+  org?: string;
+  domain?: string;
+  urlPattern?: string;
+};
+
+export type MatcherType = 'email' | 'ssn' | 'cc' | 'custom';
+
+export type Rule = {
+  id: string;
+  scope: Scope;
+  matcher: MatcherType;
+  customRegex?: string;
+  action: 'block' | 'mask' | 'allow';
+  severity: 'low' | 'medium' | 'high';
+  explain: string;
+};
+
+const MATCHERS: Record<Exclude<MatcherType, 'custom'>, RegExp> = {
+  email: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+  ssn: /\b\d{3}-\d{2}-\d{4}\b/g,
+  cc: /\b(?:\d[ -]*?){13,16}\b/g,
+};
+
+export function evaluate(text: string, rules: Rule[]) {
+  const violations: { rule: Rule; matches: string[] }[] = [];
+  let masked = text;
+
+  for (const rule of rules) {
+    let regex: RegExp | null = null;
+    if (rule.matcher === 'custom' && rule.customRegex) {
+      try {
+        regex = new RegExp(rule.customRegex, 'g');
+      } catch {
+        regex = null;
+      }
+    } else if (rule.matcher !== 'custom') {
+      regex = MATCHERS[rule.matcher];
+    }
+
+    if (regex) {
+      const matches = text.match(regex) || [];
+      if (matches.length) {
+        violations.push({ rule, matches });
+        if (rule.action === 'mask' || rule.action === 'block') {
+          masked = masked.replace(regex, '***');
+        }
+      }
+    }
+  }
+
+  return { violations, masked };
+}
+
+const STORAGE_KEY = 'policy2.rules';
+
+export function loadRules(): Rule[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveRules(rules: Rule[]) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(rules));
+  window.dispatchEvent(new Event('policy2:rules'));
+}


### PR DESCRIPTION
## Summary
- create standalone policy sandbox page with rule designer and live preview
- add policy evaluation lib with common matchers and localStorage persistence
- include sample text to demonstrate masking and violations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b23f7f8b508323a6a1b81ddc86da25