### PR TITLE
Add standalone detectors with comprehensive tests

### DIFF
--- a/lib/detectors2.ts
+++ b/lib/detectors2.ts
@@ -1,0 +1,78 @@
+export type Detection = {
+  type: 'EMAIL' | 'SSN' | 'CREDIT_CARD';
+  start: number;
+  end: number;
+  value: string;
+};
+
+const emailRegex = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const ssnRegex = /\b\d{3}-\d{2}-\d{4}\b/g;
+const ccRegex = /\b(?:\d[ -]*?){13,16}\b/g;
+
+export function isEmail(value: string): boolean {
+  emailRegex.lastIndex = 0;
+  return emailRegex.test(value);
+}
+
+export function isSSN(value: string): boolean {
+  ssnRegex.lastIndex = 0;
+  return ssnRegex.test(value);
+}
+
+function luhnCheck(num: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+  for (let i = num.length - 1; i >= 0; i--) {
+    let digit = parseInt(num.charAt(i), 10);
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    shouldDouble = !shouldDouble;
+  }
+  return sum % 10 === 0;
+}
+
+export function isCreditCard(value: string): boolean {
+  const digits = value.replace(/[^0-9]/g, '');
+  if (digits.length < 13 || digits.length > 16) return false;
+  return luhnCheck(digits);
+}
+
+export function findAll(text: string): Detection[] {
+  const results: Detection[] = [];
+
+  for (const match of text.matchAll(emailRegex)) {
+    results.push({
+      type: 'EMAIL',
+      start: match.index || 0,
+      end: (match.index || 0) + match[0].length,
+      value: match[0],
+    });
+  }
+
+  for (const match of text.matchAll(ssnRegex)) {
+    results.push({
+      type: 'SSN',
+      start: match.index || 0,
+      end: (match.index || 0) + match[0].length,
+      value: match[0],
+    });
+  }
+
+  for (const match of text.matchAll(ccRegex)) {
+    const digits = match[0].replace(/[^0-9]/g, '');
+    if (digits.length >= 13 && digits.length <= 16 && luhnCheck(digits)) {
+      results.push({
+        type: 'CREDIT_CARD',
+        start: match.index || 0,
+        end: (match.index || 0) + match[0].length,
+        value: match[0],
+      });
+    }
+  }
+
+  results.sort((a, b) => a.start - b.start);
+  return results;
+}

--- a/tests/unit2/detectors2.test.ts
+++ b/tests/unit2/detectors2.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isEmail, isSSN, isCreditCard, findAll } from '../../lib/detectors2';
+
+describe('detectors2 individual checks', () => {
+  it('validates emails', () => {
+    expect(isEmail('user@example.com')).toBe(true);
+    expect(isEmail('bad@example')).toBe(false);
+  });
+
+  it('validates SSNs', () => {
+    expect(isSSN('123-45-6789')).toBe(true);
+    expect(isSSN('123456789')).toBe(false);
+  });
+
+  it('validates credit cards via luhn', () => {
+    expect(isCreditCard('4111 1111 1111 1111')).toBe(true);
+    expect(isCreditCard('4111 1111 1111 1112')).toBe(false);
+  });
+});
+
+describe('detectors2 findAll', () => {
+  it('detects multiple entities', () => {
+    const text = 'Email user@example.com SSN 123-45-6789 card 4111-1111-1111-1111';
+    const detections = findAll(text);
+    expect(detections.map((d) => d.type)).toEqual([
+      'EMAIL',
+      'SSN',
+      'CREDIT_CARD',
+    ]);
+  });
+
+  it('handles overlaps', () => {
+    const text = 'Contact 123-45-6789@example.com now';
+    const detections = findAll(text);
+    expect(detections.some((d) => d.type === 'EMAIL')).toBe(true);
+    expect(detections.some((d) => d.type === 'SSN')).toBe(true);
+  });
+
+  it('returns empty for none', () => {
+    expect(findAll('nothing here').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add isolated detection utilities for email, SSN, and credit cards with Luhn validation
- expose `findAll` helper returning typed matches
- cover validators with positive, negative, and overlap unit tests

## Testing
- `npm test`
- `npx vitest run tests/unit2/detectors2.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b23fb979088323a7b44a40f3030e29