### PR TITLE
feat: add lightweight telemetry module

### DIFF
--- a/app/(ops)/telemetry-dev/page.tsx
+++ b/app/(ops)/telemetry-dev/page.tsx
@@ -1,0 +1,14 @@
+import TelemetryDevTap from '@/components/TelemetryDevTap';
+
+export default function TelemetryDevPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <TelemetryDevTap />
+      <h1 className="text-xl font-bold">Telemetry Dev</h1>
+      <p>
+        Use the <code>track</code> helper to capture analytics events in your pages.
+      </p>
+      <pre className="rounded bg-gray-100 p-2 text-xs">{`import { track } from '@/lib/telemetry/client';\n\ntrack('view', { page: 'home' });`}</pre>
+    </div>
+  );
+}

--- a/app/api/telemetry2/route.ts
+++ b/app/api/telemetry2/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+
+export interface TelemetryEvent {
+  event: string;
+  props?: Record<string, any>;
+  ts: number;
+}
+
+export const events: TelemetryEvent[] = [];
+
+export async function POST(request: Request) {
+  try {
+    const { event, props = {}, ts = Date.now() } = await request.json();
+    const payload: TelemetryEvent = { event, props, ts };
+    events.push(payload);
+
+    const dir = path.join(process.cwd(), '.data', 'telemetry');
+    await fs.promises.mkdir(dir, { recursive: true });
+    const file = path.join(dir, 'events.ndjson');
+    await fs.promises.appendFile(file, JSON.stringify(payload) + '\n');
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/components/TelemetryDevTap.tsx
+++ b/components/TelemetryDevTap.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { getRecentEvents, flush, TelemetryEvent } from '@/lib/telemetry/client';
+
+export default function TelemetryDevTap() {
+  const [events, setEvents] = useState<TelemetryEvent[]>([]);
+
+  useEffect(() => {
+    const update = () => setEvents(getRecentEvents());
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-72 max-h-64 overflow-y-auto border bg-white p-2 text-xs shadow">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-semibold">Telemetry</span>
+        <button onClick={flush} className="text-blue-600 underline">Flush</button>
+      </div>
+      <ul className="space-y-1">
+        {events.slice(-20).map((e, i) => (
+          <li key={i} className="break-all">
+            {e.event}: {e.props && Object.keys(e.props).length ? JSON.stringify(e.props) : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lib/telemetry/client.ts
+++ b/lib/telemetry/client.ts
@@ -1,0 +1,66 @@
+export interface TelemetryEvent {
+  event: string;
+  props?: Record<string, any>;
+  ts: number;
+}
+
+const STORAGE_KEY = 'telemetry_buffer';
+const recent: TelemetryEvent[] = [];
+
+function readBuffer(): TelemetryEvent[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function writeBuffer(events: TelemetryEvent[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+}
+
+async function send(ev: TelemetryEvent) {
+  await fetch('/api/telemetry2', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(ev),
+  });
+}
+
+export async function flush() {
+  if (typeof localStorage === 'undefined') return;
+  const buffer = readBuffer();
+  const remaining: TelemetryEvent[] = [];
+  for (const ev of buffer) {
+    try {
+      await send(ev);
+    } catch {
+      remaining.push(ev);
+    }
+  }
+  writeBuffer(remaining);
+}
+
+export async function track(event: string, props: Record<string, any> = {}) {
+  if (typeof localStorage === 'undefined') return;
+  const ev: TelemetryEvent = { event, props, ts: Date.now() };
+  recent.push(ev);
+  try {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      throw new Error('offline');
+    }
+    await send(ev);
+    await flush();
+  } catch {
+    const buffer = readBuffer();
+    buffer.push(ev);
+    writeBuffer(buffer);
+  }
+}
+
+export function getRecentEvents(): TelemetryEvent[] {
+  if (typeof localStorage === 'undefined') {
+    return recent.slice(-20);
+  }
+  return [...readBuffer(), ...recent].slice(-20);
+}

--- a/tests/unit/telemetry2.test.ts
+++ b/tests/unit/telemetry2.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { track, flush } from '../../lib/telemetry/client';
+import { POST, events } from '../../app/api/telemetry2/route';
+import fs from 'fs';
+import path from 'path';
+
+describe('telemetry client', () => {
+  const store: Record<string, string> = {};
+  beforeEach(() => {
+    Object.keys(store).forEach((k) => delete store[k]);
+    globalThis.localStorage = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k]);
+      },
+    } as any;
+    globalThis.fetch = vi.fn();
+    globalThis.navigator = { onLine: true } as any;
+  });
+
+  it('buffers events when offline', async () => {
+    navigator.onLine = false;
+    await track('test');
+    const buf = JSON.parse(localStorage.getItem('telemetry_buffer') || '[]');
+    expect(buf.length).toBe(1);
+  });
+
+  it('flush sends buffered events', async () => {
+    navigator.onLine = false;
+    await track('test2');
+    navigator.onLine = true;
+    (fetch as any).mockResolvedValue({ ok: true });
+    await flush();
+    const buf = JSON.parse(localStorage.getItem('telemetry_buffer') || '[]');
+    expect(buf.length).toBe(0);
+    expect((fetch as any).mock.calls.length).toBe(1);
+  });
+});
+
+describe('telemetry route', () => {
+  const dir = path.join(process.cwd(), '.data', 'telemetry');
+  const file = path.join(dir, 'events.ndjson');
+  beforeEach(async () => {
+    events.length = 0;
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes events to ndjson', async () => {
+    const req = new Request('http://localhost/api/telemetry2', {
+      method: 'POST',
+      body: JSON.stringify({ event: 'api', props: { a: 1 }, ts: 1 }),
+    });
+    await POST(req);
+    expect(events.length).toBe(1);
+    const content = await fs.promises.readFile(file, 'utf-8');
+    const line = JSON.parse(content.trim());
+    expect(line.event).toBe('api');
+  });
+});


### PR DESCRIPTION
## Summary
- capture events via client-side telemetry helper with offline buffering
- store telemetry events on the server and expose a dev widget for inspection
- document usage and cover with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2429eb98c83239c731852ddbb151e