### PR TITLE
feat: add lead webhook relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+# Runtime data
+.data

--- a/app/api/lead-webhook/route.ts
+++ b/app/api/lead-webhook/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { appendFile, mkdir } from 'fs/promises';
+import path from 'path';
+
+interface LeadPayload {
+  name: string;
+  email: string;
+  company: string;
+  notes: string;
+}
+
+function isValidEmail(email: string): boolean {
+  return /.+@.+\..+/.test(email);
+}
+
+async function savePending(payload: LeadPayload) {
+  const dir = path.join(process.cwd(), '.data', 'leads');
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'pending.ndjson');
+  await appendFile(file, JSON.stringify(payload) + '\n');
+}
+
+export async function POST(request: Request) {
+  try {
+    const { name, email, company, notes } = (await request.json()) as Partial<LeadPayload>;
+    if (!name || !email || !company || !notes || !isValidEmail(email)) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+
+    const payload: LeadPayload = { name, email, company, notes };
+    const webhookUrl = process.env.LEAD_WEBHOOK_URL;
+
+    if (webhookUrl) {
+      try {
+        const res = await fetch(webhookUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          await savePending(payload);
+          return NextResponse.json({ error: 'Webhook error' }, { status: 502 });
+        }
+      } catch {
+        await savePending(payload);
+        return NextResponse.json({ error: 'Webhook error' }, { status: 502 });
+      }
+      return NextResponse.json({ success: true }, { status: 200 });
+    }
+
+    await savePending(payload);
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/ops/LEADS_WEBHOOK.md
+++ b/ops/LEADS_WEBHOOK.md
@@ -1,0 +1,27 @@
+# Leads Webhook Relay
+
+The `/api/lead-webhook` route forwards lead submissions to an external
+URL or stores them locally when no endpoint is configured.
+
+## Google Sheets via Apps Script
+1. Create a new Google Apps Script project.
+2. Add a `doPost(e)` function that appends `e.postData.contents` to a
+   Google Sheet.
+3. Deploy as a web app that allows **Anyone** to access and copy the
+   generated URL.
+
+## Zapier
+1. Create a new Zap using the **Webhook → Catch Hook** trigger.
+2. Copy the provided webhook URL.
+
+## Environment Variable
+Set the webhook URL in `LEAD_WEBHOOK_URL` (e.g. in `.env` or your
+hosting provider's dashboard). When defined, incoming leads are `POST`
+ed to this URL as JSON.
+
+## Fallback Storage
+If `LEAD_WEBHOOK_URL` is undefined or the webhook request fails,
+submissions are appended to `.data/leads/pending.ndjson`.
+
+Use `scripts/replay-leads.ts` to resend any pending entries once the
+webhook is available.

--- a/scripts/replay-leads.ts
+++ b/scripts/replay-leads.ts
@@ -1,0 +1,46 @@
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+
+async function main() {
+  const webhook = process.env.LEAD_WEBHOOK_URL;
+  if (!webhook) {
+    console.error('LEAD_WEBHOOK_URL is not set');
+    process.exit(1);
+  }
+
+  const file = path.join(process.cwd(), '.data', 'leads', 'pending.ndjson');
+  let data: string;
+  try {
+    data = await readFile(file, 'utf-8');
+  } catch {
+    console.log('No pending leads');
+    return;
+  }
+
+  const lines = data.split('\n').filter(Boolean);
+  const remaining: string[] = [];
+
+  for (const line of lines) {
+    try {
+      const payload = JSON.parse(line);
+      const res = await fetch(webhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        console.log('Sent', payload.email);
+      } else {
+        remaining.push(line);
+        console.error('Failed', payload.email, res.status);
+      }
+    } catch (err) {
+      remaining.push(line);
+      console.error('Error sending lead', err);
+    }
+  }
+
+  await writeFile(file, remaining.join('\n') + (remaining.length ? '\n' : ''));
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `/api/lead-webhook` route that forwards leads to `LEAD_WEBHOOK_URL` or stores them locally
- Document webhook setup and fallback storage in `ops/LEADS_WEBHOOK.md`
- Provide `scripts/replay-leads.ts` to resend queued leads when webhook becomes available

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b242ae71948323bb286525cab8ea50