### PR TITLE
feat: add policy pack browser

### DIFF
--- a/app/(console)/policy-packs/page.tsx
+++ b/app/(console)/policy-packs/page.tsx
@@ -1,0 +1,36 @@
+import { listPolicyPacks } from '@/lib/policy-packs';
+
+export default async function PolicyPacksPage() {
+  const packs = await listPolicyPacks();
+  return (
+    <section className="p-8 space-y-6">
+      <h1 className="text-3xl font-bold">Policy Packs</h1>
+      <ul className="space-y-6">
+        {packs.map(({ name, rules }) => {
+          const json = JSON.stringify(rules, null, 2);
+          return (
+            <li key={name} className="border rounded p-4 space-y-2">
+              <h2 className="text-xl font-semibold capitalize">{name}</h2>
+              <pre className="bg-gray-100 p-2 overflow-x-auto text-sm">{json}</pre>
+              <div className="flex gap-4 text-sm">
+                <a
+                  href={`data:application/json,${encodeURIComponent(json)}`}
+                  download={`${name}.json`}
+                  className="underline text-blue-600"
+                >
+                  Export
+                </a>
+                <a
+                  href={`/console-sandbox2?pack=${name}`}
+                  className="underline text-blue-600"
+                >
+                  Try in Sandbox
+                </a>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/data/policy-packs/gdpr.json
+++ b/data/policy-packs/gdpr.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "gdpr-email",
+    "name": "Mask Email Addresses",
+    "scope": {"domain": "*.eu"},
+    "matchers": [{"type": "email"}],
+    "action": "mask",
+    "severity": "medium",
+    "explain": "Emails are personal data under GDPR and should be masked unless consented."
+  },
+  {
+    "id": "gdpr-phone",
+    "name": "Block EU Phone Numbers",
+    "scope": {"domain": "*.eu"},
+    "matchers": [{"type": "custom", "pattern": "\\+?\\d{2} ?\\d{4,14}"}],
+    "action": "block",
+    "severity": "high",
+    "explain": "Phone numbers require explicit consent for processing."
+  },
+  {
+    "id": "gdpr-address",
+    "name": "Mask Mailing Addresses",
+    "scope": {},
+    "matchers": [{"type": "custom", "pattern": "\\d+\\s+\\w+\\s+(Street|St|Ave|Avenue)"}],
+    "action": "mask",
+    "severity": "low",
+    "explain": "Physical addresses are personal data and should be masked."
+  }
+]

--- a/data/policy-packs/hipaa.json
+++ b/data/policy-packs/hipaa.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "hipaa-email",
+    "name": "Mask PHI Emails",
+    "scope": {"domain": "*.hospital.example"},
+    "matchers": [{"type": "email"}],
+    "action": "mask",
+    "severity": "high",
+    "explain": "Email addresses may expose protected health information and must be masked."
+  },
+  {
+    "id": "hipaa-ssn",
+    "name": "Block Social Security Numbers",
+    "scope": {},
+    "matchers": [{"type": "ssn"}],
+    "action": "block",
+    "severity": "high",
+    "explain": "SSNs are considered PHI and should be blocked from transmission."
+  },
+  {
+    "id": "hipaa-mrn",
+    "name": "Mask Medical Record Numbers",
+    "scope": {},
+    "matchers": [{"type": "custom", "pattern": "\\bMRN\\s*\\d{6}\\b"}],
+    "action": "mask",
+    "severity": "medium",
+    "explain": "Medical record numbers must be masked to protect patient identity."
+  }
+]

--- a/data/policy-packs/pci.json
+++ b/data/policy-packs/pci.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "pci-card",
+    "name": "Block Credit Card Numbers",
+    "scope": {},
+    "matchers": [{"type": "cc"}],
+    "action": "block",
+    "severity": "high",
+    "explain": "Credit card numbers must never be stored or transmitted."
+  },
+  {
+    "id": "pci-cvv",
+    "name": "Block CVV Codes",
+    "scope": {},
+    "matchers": [{"type": "custom", "pattern": "\\b\\d{3,4}\\b"}],
+    "action": "block",
+    "severity": "high",
+    "explain": "CVV codes are sensitive authentication data and should be blocked."
+  },
+  {
+    "id": "pci-exp",
+    "name": "Mask Card Expiration Dates",
+    "scope": {},
+    "matchers": [{"type": "custom", "pattern": "\\b(0[1-9]|1[0-2])\\/\\d{2}\\b"}],
+    "action": "mask",
+    "severity": "medium",
+    "explain": "Expiration dates should be masked on receipts and logs."
+  }
+]

--- a/lib/policy-packs.ts
+++ b/lib/policy-packs.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import Ajv from 'ajv';
+import schema from '../schemas/policy2.schema.json';
+
+export type PolicyRule = {
+  id: string | number;
+  name: string;
+  scope: Record<string, any>;
+  matchers: Record<string, any>[];
+  action: string;
+  severity: string;
+  explain: string;
+};
+
+const ajv = new Ajv();
+const validate = ajv.compile<PolicyRule>(schema as any);
+
+export const POLICY_PACKS = ['hipaa', 'gdpr', 'pci'] as const;
+export type PolicyPackName = typeof POLICY_PACKS[number];
+
+export async function loadPolicyPack(name: PolicyPackName): Promise<PolicyRule[]> {
+  const file = path.join(process.cwd(), 'data', 'policy-packs', `${name}.json`);
+  const raw = await fs.promises.readFile(file, 'utf-8');
+  const json = JSON.parse(raw);
+  if (!Array.isArray(json)) {
+    throw new Error('Policy pack must be an array of rules');
+  }
+  for (const rule of json) {
+    if (!validate(rule)) {
+      throw new Error(`Invalid rule in ${name}: ${ajv.errorsText(validate.errors)}`);
+    }
+  }
+  return json as PolicyRule[];
+}
+
+export async function listPolicyPacks() {
+  return Promise.all(
+    POLICY_PACKS.map(async (name) => ({ name, rules: await loadPolicyPack(name) }))
+  );
+}

--- a/tests/unit/policy-packs.test.ts
+++ b/tests/unit/policy-packs.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { POLICY_PACKS, loadPolicyPack } from '../../lib/policy-packs';
+
+describe('policy packs', () => {
+  it('loads and validates all packs', async () => {
+    for (const name of POLICY_PACKS) {
+      const pack = await loadPolicyPack(name);
+      expect(Array.isArray(pack)).toBe(true);
+      expect(pack.length).toBeGreaterThan(0);
+      for (const rule of pack) {
+        expect(rule).toHaveProperty('id');
+        expect(rule).toHaveProperty('name');
+        expect(rule).toHaveProperty('matchers');
+        expect(rule).toHaveProperty('action');
+        expect(rule).toHaveProperty('severity');
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add HIPAA/GDPR/PCI policy packs with matchers
- load and validate packs via Ajv
- new console page to view/export packs and launch sandbox
- tests for pack validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b242bcc7c88323b227e0fc1d5caf35