### PR TITLE
feat: add guided tour demo

### DIFF
--- a/README_TOUR.md
+++ b/README_TOUR.md
@@ -1,0 +1,17 @@
+# Guided Tour Demo Script
+
+Use this 30-second walkthrough to showcase the product tour at `/tour`.
+
+1. **Paste text** – Start with some sample sensitive text.
+2. **Scan** – Trigger a scan to detect entities.
+3. **Findings** – Point out the detected PII/PHI results.
+4. **Mask** – Show how data is redacted or masked.
+5. **Policy** – Highlight how policies govern the redaction behavior.
+6. **Export** – Finish by exporting the sanitized output.
+
+Controls:
+- Use the **Skip** button to jump to the end of the tour.
+- Click **Restart** to begin again from step one.
+- Arrow keys (←/→) also move between steps.
+
+This script is intended for founders running quick sales demos.

--- a/app/(demo)/tour/page.tsx
+++ b/app/(demo)/tour/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+import TourCoach from '@/components/TourCoach';
+
+const steps = ['Paste text', 'Scan', 'Findings', 'Mask', 'Policy', 'Export'];
+
+export default function TourPage() {
+  return (
+    <TourCoach steps={steps}>
+      {({ step, stepTitle, steps, isFinished, next, prev, skip, restart }) => (
+        <section className="p-8 space-y-6">
+          <h1 className="text-3xl font-bold">Guided Product Tour</h1>
+          <div className="grid grid-cols-3 gap-4">
+            {steps.map((title, index) => (
+              <div
+                key={title}
+                className={`p-4 border rounded text-center text-sm ${
+                  index === step ? 'bg-emerald-50 border-emerald-500' : 'bg-white'
+                }`}
+              >
+                {title}
+              </div>
+            ))}
+          </div>
+          {isFinished ? (
+            <p className="text-sm">Tour complete.</p>
+          ) : (
+            <p className="text-sm">
+              Step {step + 1} of {steps.length}: {stepTitle}
+            </p>
+          )}
+          <div className="flex gap-2">
+            <button
+              className="px-2 py-1 border rounded"
+              onClick={prev}
+              disabled={step === 0}
+            >
+              Prev
+            </button>
+            <button
+              className="px-2 py-1 border rounded"
+              onClick={next}
+              disabled={step >= steps.length - 1}
+            >
+              Next
+            </button>
+            <button className="px-2 py-1 border rounded" onClick={skip}>
+              Skip
+            </button>
+            <button className="px-2 py-1 border rounded" onClick={restart}>
+              Restart
+            </button>
+          </div>
+          <p className="text-xs text-dark-400">Use ←/→ keys to navigate.</p>
+        </section>
+      )}
+    </TourCoach>
+  );
+}
+

--- a/components/TourCoach.tsx
+++ b/components/TourCoach.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useCallback, useEffect, useState, ReactNode } from 'react';
+
+export type TourCoachRenderProps = {
+  step: number;
+  stepTitle: string;
+  steps: string[];
+  isFinished: boolean;
+  next: () => void;
+  prev: () => void;
+  skip: () => void;
+  restart: () => void;
+};
+
+interface TourCoachProps {
+  steps: string[];
+  storageKey?: string;
+  children: (props: TourCoachRenderProps) => ReactNode;
+}
+
+export default function TourCoach({ steps, storageKey = 'tour-step', children }: TourCoachProps) {
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(storageKey);
+    if (stored !== null) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed)) {
+        setStep(parsed);
+      }
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    sessionStorage.setItem(storageKey, String(step));
+  }, [step, storageKey]);
+
+  const next = useCallback(() => {
+    setStep((s) => Math.min(s + 1, steps.length));
+  }, [steps.length]);
+
+  const prev = useCallback(() => {
+    setStep((s) => Math.max(s - 1, 0));
+  }, []);
+
+  const skip = useCallback(() => {
+    setStep(steps.length);
+  }, [steps.length]);
+
+  const restart = useCallback(() => {
+    setStep(0);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') {
+        next();
+      } else if (e.key === 'ArrowLeft') {
+        prev();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [next, prev]);
+
+  const isFinished = step >= steps.length;
+  const stepTitle = steps[step] ?? '';
+
+  return <>{children({ step, stepTitle, steps, isFinished, next, prev, skip, restart })}</>;
+}
+


### PR DESCRIPTION
## Summary
- add headless TourCoach engine for step-based tours with session storage and keyboard navigation
- add demo tour page showcasing 6-step flow with skip and restart controls
- document 30-second demo script for founders

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b242cd79688323aa1c77cec7fefd22