### PR TITLE
Add ROI PDF export and calculator

### DIFF
--- a/app/(marketing)/roi-export/page.tsx
+++ b/app/(marketing)/roi-export/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useState } from 'react';
+import assumptions from '@/data/roi2/assumptions.json';
+import { calculateRoi } from '@/lib/roi2/calc';
+
+export default function RoiExportPage() {
+  const [inputs, setInputs] = useState({
+    seats: assumptions.seats,
+    promptsPerUserPerDay: assumptions.promptsPerUserPerDay,
+    incidentRatePercent: assumptions.incidentRatePercent,
+    costPerIncident: assumptions.costPerIncident,
+    wagePerHour: assumptions.wagePerHour,
+    licenseCostPerSeatPerMonth: assumptions.licenseCostPerSeatPerMonth,
+  });
+
+  const onChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputs({ ...inputs, [field]: Number(e.target.value) });
+  };
+
+  const handleDownload = async () => {
+    const assumptionsData = { ...inputs, secondsSavedPerPrompt: assumptions.secondsSavedPerPrompt };
+    const outputs = calculateRoi(assumptionsData);
+    const res = await fetch('/api/roi2/pdf', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assumptions: assumptionsData, outputs }),
+    });
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'SGAI_ROI_Report.pdf';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section className="p-8 space-y-4 text-sm">
+      <h1 className="text-3xl font-bold mb-4">ROI PDF Export</h1>
+      <div className="space-y-2">
+        <label>
+          Seats:
+          <input type="number" value={inputs.seats} onChange={onChange('seats')} className="ml-2 text-black" />
+        </label>
+        <label className="block">
+          Prompts/user/day:
+          <input type="number" value={inputs.promptsPerUserPerDay} onChange={onChange('promptsPerUserPerDay')} className="ml-2 text-black" />
+        </label>
+        <label className="block">
+          Incident rate %:
+          <input type="number" value={inputs.incidentRatePercent} onChange={onChange('incidentRatePercent')} className="ml-2 text-black" />
+        </label>
+        <label className="block">
+          Cost/incident ($):
+          <input type="number" value={inputs.costPerIncident} onChange={onChange('costPerIncident')} className="ml-2 text-black" />
+        </label>
+        <label className="block">
+          Wage/hr ($):
+          <input type="number" value={inputs.wagePerHour} onChange={onChange('wagePerHour')} className="ml-2 text-black" />
+        </label>
+        <label className="block">
+          License price/mo ($):
+          <input type="number" value={inputs.licenseCostPerSeatPerMonth} onChange={onChange('licenseCostPerSeatPerMonth')} className="ml-2 text-black" />
+        </label>
+      </div>
+      <button onClick={handleDownload} className="px-4 py-2 bg-blue-600 text-white rounded">
+        Download PDF
+      </button>
+    </section>
+  );
+}

--- a/app/api/roi2/pdf/route.ts
+++ b/app/api/roi2/pdf/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { generateRoiReport } from '@/lib/pdf/roiReport';
+
+export async function POST(req: Request) {
+  try {
+    const data = await req.json();
+    const pdf = await generateRoiReport(data);
+    return new NextResponse(pdf, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="SGAI_ROI_Report.pdf"',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/lib/pdf/roiReport.ts
+++ b/lib/pdf/roiReport.ts
@@ -1,0 +1,35 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+
+interface RoiReportData {
+  assumptions: Record<string, number>;
+  outputs: Record<string, number>;
+}
+
+export async function generateRoiReport(data: RoiReportData): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+
+  // Page 1 - Assumptions
+  const page1 = doc.addPage();
+  let { height } = page1.getSize();
+  page1.drawText('SGAI ROI Report', { x: 50, y: height - 50, size: 24, font });
+  page1.drawText('Assumptions', { x: 50, y: height - 80, size: 18, font });
+  let y = height - 110;
+  for (const [key, value] of Object.entries(data.assumptions)) {
+    page1.drawText(`${key}: ${value}`, { x: 50, y, size: 12, font });
+    y -= 20;
+  }
+
+  // Page 2 - Outputs
+  const page2 = doc.addPage();
+  height = page2.getSize().height;
+  page2.drawText('Results', { x: 50, y: height - 50, size: 24, font });
+  y = height - 90;
+  for (const [key, value] of Object.entries(data.outputs)) {
+    const text = `${key}: ${typeof value === 'number' ? value.toFixed(2) : value}`;
+    page2.drawText(text, { x: 50, y, size: 12, font });
+    y -= 20;
+  }
+
+  return doc.save();
+}

--- a/lib/roi2/calc.ts
+++ b/lib/roi2/calc.ts
@@ -1,0 +1,47 @@
+export interface RoiInputs {
+  seats: number;
+  promptsPerUserPerDay: number;
+  incidentRatePercent: number;
+  costPerIncident: number;
+  wagePerHour: number;
+  secondsSavedPerPrompt: number;
+  licenseCostPerSeatPerMonth: number;
+}
+
+export interface RoiOutputs {
+  totalPromptsPerDay: number;
+  incidentsPerYear: number;
+  avoidedExposure: number;
+  hoursSavedPerYear: number;
+  timeSavings: number;
+  annualBenefits: number;
+  annualCost: number;
+  roi: number;
+  paybackMonths: number;
+}
+
+export function calculateRoi(inputs: RoiInputs): RoiOutputs {
+  const totalPromptsPerDay = inputs.seats * inputs.promptsPerUserPerDay;
+  const incidentsPerYear = totalPromptsPerDay * 365 * (inputs.incidentRatePercent / 100);
+  const avoidedExposure = incidentsPerYear * inputs.costPerIncident;
+
+  const hoursSavedPerYear = totalPromptsPerDay * 365 * (inputs.secondsSavedPerPrompt / 3600);
+  const timeSavings = hoursSavedPerYear * inputs.wagePerHour;
+
+  const annualBenefits = avoidedExposure + timeSavings;
+  const annualCost = inputs.seats * inputs.licenseCostPerSeatPerMonth * 12;
+  const roi = annualCost > 0 ? ((annualBenefits - annualCost) / annualCost) * 100 : 0;
+  const paybackMonths = annualBenefits > 0 ? (annualCost * 12) / annualBenefits : 0;
+
+  return {
+    totalPromptsPerDay,
+    incidentsPerYear,
+    avoidedExposure,
+    hoursSavedPerYear,
+    timeSavings,
+    annualBenefits,
+    annualCost,
+    roi,
+    paybackMonths,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "framer-motion": "^11.3.13",
         "lucide-react": "^0.344.0",
         "next": "14.2.3",
+        "pdf-lib": "^1.17.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hook-form": "^7.51.3",
@@ -915,6 +916,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -5536,6 +5555,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5629,6 +5654,24 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^11.3.13",
     "lucide-react": "^0.344.0",
     "next": "14.2.3",
+    "pdf-lib": "^1.17.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.51.3",

--- a/tests/unit/roiCalc.test.ts
+++ b/tests/unit/roiCalc.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRoi } from '../../lib/roi2/calc';
+
+describe('calculateRoi', () => {
+  it('computes ROI metrics', () => {
+    const inputs = {
+      seats: 100,
+      promptsPerUserPerDay: 20,
+      incidentRatePercent: 5,
+      costPerIncident: 100,
+      wagePerHour: 40,
+      secondsSavedPerPrompt: 30,
+      licenseCostPerSeatPerMonth: 25,
+    };
+    const result = calculateRoi(inputs);
+    expect(result.totalPromptsPerDay).toBe(2000);
+    expect(result.avoidedExposure).toBe(3650000);
+    expect(result.roi).toBeCloseTo(12877.8, 1);
+    expect(result.paybackMonths).toBeCloseTo(0.0925, 4);
+  });
+});


### PR DESCRIPTION
## Summary
- add calculator utility for ROI metrics
- implement PDF report generator and API endpoint
- create marketing page for ROI PDF export with download button
- test ROI calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b242e04e8883239bd8e923b0cb0356