### PR TITLE
chore: add dev docker tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ VITE_SCRAPER_API_BASE_URL="https://api.example.com"
 
 # OpenAI key for Strategy Builder
 OPENAI_API_KEY="sk-..."
+
+# Lead capture webhook
+LEAD_WEBHOOK_URL=""

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,18 @@
+# Development Dockerfile using Node LTS
+FROM node:lts
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies first to leverage Docker layer caching
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the Next.js dev port
+EXPOSE 3000
+
+# Default command will be overridden by docker-compose for dev
+CMD ["npm", "run", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+COMPOSE=docker compose -f docker-compose.dev.yml
+SERVICE=sgai-web
+
+.PHONY: up down logs test lint
+
+up:
+	$(COMPOSE) up -d
+
+down:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f
+
+test:
+	$(COMPOSE) run --rm $(SERVICE) npm test
+
+lint:
+	$(COMPOSE) run --rm $(SERVICE) npm run lint

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  sgai-web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - .data:/app/.data
+    command: npm run dev

--- a/docs/DEV_ONBOARDING.md
+++ b/docs/DEV_ONBOARDING.md
@@ -1,0 +1,23 @@
+# Dev Onboarding
+
+Get the local stack running in under three minutes.
+
+## Quickstart
+
+1. Copy env vars:
+   ```bash
+   cp .env.example .env
+   ```
+2. Launch services:
+   ```bash
+   make up
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Useful Commands
+- View logs: `make logs`
+- Run tests: `make test`
+- Lint code: `make lint`
+- Stop services: `make down`
+
+The container mounts your code and `.data/` directory so changes reflect immediately.


### PR DESCRIPTION
## Summary
- containerize development setup with Dockerfile.dev and compose config
- add Makefile helpers for dev, test, lint workflows
- document quickstart onboarding and sample env vars

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b242f1cfe08323a076318f234a1a5e