### PR TITLE
Add API auth middleware with rate limiting

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,6 @@
+# Security
+
+## API Keys & Rate Limits
+- Protected API routes require `Authorization: Bearer <SGAI_API_KEY>`.
+- Requests are limited to 60 per 5 minutes per IP.
+- Exceeding the limit returns `429` with a `Retry-After` header.

--- a/lib/security/index.ts
+++ b/lib/security/index.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+
+export function getRequestId(req: Request): string {
+  return req.headers.get('x-request-id') || randomUUID();
+}
+
+export function withSecurityHeaders(res: NextResponse, requestId: string) {
+  res.headers.set('X-Request-ID', requestId);
+  res.headers.set('Cache-Control', 'no-store');
+  return res;
+}
+
+export function jsonError(
+  status: number,
+  message: string,
+  requestId: string,
+  headers: Record<string, string> = {}
+) {
+  const res = withSecurityHeaders(
+    NextResponse.json({ error: message, requestId }, { status }),
+    requestId
+  );
+  for (const [k, v] of Object.entries(headers)) {
+    res.headers.set(k, v);
+  }
+  return res;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRequestId, jsonError, withSecurityHeaders } from './lib/security';
+
+const RATE_LIMIT = 60;
+const WINDOW_MS = 5 * 60 * 1000;
+const MAX_ENTRIES = 1000;
+const hits = new Map<string, number[]>();
+
+function record(ip: string, now: number) {
+  let timestamps = hits.get(ip) || [];
+  timestamps = timestamps.filter((t) => now - t < WINDOW_MS);
+  timestamps.push(now);
+  hits.set(ip, timestamps);
+  if (hits.size > MAX_ENTRIES) {
+    const oldest = hits.keys().next().value;
+    hits.delete(oldest);
+  }
+  return timestamps;
+}
+
+export default function middleware(req: NextRequest) {
+  const requestId = getRequestId(req);
+  const expected = `Bearer ${process.env.SGAI_API_KEY}`;
+  const auth = req.headers.get('authorization');
+  if (auth !== expected) {
+    return jsonError(401, 'Unauthorized', requestId);
+  }
+
+  const ip = req.ip || req.headers.get('x-forwarded-for') || 'unknown';
+  const now = Date.now();
+  const timestamps = record(ip, now);
+  const recent = timestamps.filter((t) => now - t < WINDOW_MS);
+  if (recent.length > RATE_LIMIT) {
+    const retry = Math.ceil((WINDOW_MS - (now - recent[0])) / 1000);
+    return jsonError(429, 'Rate limit exceeded', requestId, {
+      'Retry-After': String(retry),
+    });
+  }
+
+  return withSecurityHeaders(NextResponse.next(), requestId);
+}
+
+export const config = {
+  matcher: ['/api/(leads|telemetry|pii|pdf)/:path*'],
+};
+
+export function _resetRateLimit() {
+  hits.clear();
+}

--- a/tests/security/middleware.auth.test.ts
+++ b/tests/security/middleware.auth.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import middleware, { _resetRateLimit } from '../../middleware';
+import { NextRequest } from 'next/server';
+
+function makeReq(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/leads', { headers });
+}
+
+describe('middleware auth', () => {
+  beforeEach(() => {
+    _resetRateLimit();
+    process.env.SGAI_API_KEY = 'test';
+  });
+
+  it('rejects missing key', async () => {
+    const res = await middleware(makeReq());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(res.headers.get('X-Request-ID')).toBeTruthy();
+  });
+
+  it('allows valid key', async () => {
+    const res = await middleware(
+      makeReq({ Authorization: 'Bearer test', 'x-forwarded-for': '1.1.1.1' })
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/security/middleware.ratelimit.test.ts
+++ b/tests/security/middleware.ratelimit.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import middleware, { _resetRateLimit } from '../../middleware';
+import { NextRequest } from 'next/server';
+
+function makeReq() {
+  return new NextRequest('http://localhost/api/leads', {
+    headers: {
+      Authorization: 'Bearer test',
+      'x-forwarded-for': '2.2.2.2',
+    },
+  });
+}
+
+describe('middleware rate limit', () => {
+  beforeEach(() => {
+    _resetRateLimit();
+    process.env.SGAI_API_KEY = 'test';
+  });
+
+  it('limits requests per ip', async () => {
+    for (let i = 0; i < 60; i++) {
+      const ok = await middleware(makeReq());
+      expect(ok.status).toBe(200);
+    }
+    const res = await middleware(makeReq());
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- enforce API key auth and sliding window rate limiting on sensitive API routes via new Next.js middleware
- centralize security headers and JSON error responses with request-id correlation
- document API key usage and rate limits

## Testing
- `npx vitest run tests/security`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b24783bff88323b70bebd7a3fc58b5