### PR TITLE
feat: add privacy safeguards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist-ssr
 
 # Runtime data
 .data
+
+.logs

--- a/app/api/telemetry/route.ts
+++ b/app/api/telemetry/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { maskEmail, maskPhone, maskSSN, maskName } from '@/lib/privacy/mask';
+import { writeAudit } from '@/lib/audit/logger';
+
+export interface TelemetryEvent {
+  event: string;
+  props?: Record<string, any>;
+  ts: number;
+  masked: boolean;
+}
+
+function maskProps(props: Record<string, any>): Record<string, any> {
+  const out: Record<string, any> = { ...props };
+  if (typeof out.email === 'string') out.email = maskEmail(out.email);
+  if (typeof out.phone === 'string') out.phone = maskPhone(out.phone);
+  if (typeof out.ssn === 'string') out.ssn = maskSSN(out.ssn);
+  if (typeof out.name === 'string') out.name = maskName(out.name);
+  return out;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { event, props = {}, ts = Date.now() } = await request.json();
+    const maskedProps = maskProps(props);
+    const payload: TelemetryEvent = { event, props: maskedProps, ts, masked: true };
+
+    const dir = path.join(process.cwd(), '.data', 'telemetry');
+    await fs.promises.mkdir(dir, { recursive: true });
+    const file = path.join(dir, 'events.ndjson');
+    await fs.promises.appendFile(file, JSON.stringify(payload) + '\n');
+
+    const requestId = request.headers.get('x-request-id') || crypto.randomUUID();
+    await writeAudit({ action: 'create', requestId, timestamp: Date.now(), record: payload });
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,15 @@
+# Privacy Controls
+
+This project prevents raw personally identifiable information (PII) from being stored.
+
+## Masking
+
+`lib/privacy/mask.ts` deterministically hashes emails, phone numbers, Social Security numbers, and names with a salt while preserving the last two characters. The `/api/telemetry` endpoint applies this masking before writing events and marks records with `"masked": true`.
+
+## Retention
+
+`scripts/retention.ts` removes telemetry events older than `TELEMETRY_RETENTION_DAYS` (30 days by default). Run `npm run retention` to execute the cleanup locally.
+
+## Audit Trails
+
+`lib/audit/logger.ts` writes append‑only JSON lines to `.logs/audit-YYYY-MM-DD.jsonl`. Each create or delete operation includes a request id and timestamp for later inspection.

--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface AuditEntry {
+  action: 'create' | 'delete';
+  requestId: string;
+  timestamp: number;
+  record: any;
+}
+
+export async function writeAudit(entry: AuditEntry): Promise<void> {
+  const dir = path.join(process.cwd(), '.logs');
+  await fs.mkdir(dir, { recursive: true });
+  const date = new Date().toISOString().slice(0, 10);
+  const file = path.join(dir, `audit-${date}.jsonl`);
+  await fs.appendFile(file, JSON.stringify(entry) + '\n');
+}

--- a/lib/privacy/mask.ts
+++ b/lib/privacy/mask.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+const SALT = process.env.PRIVACY_SALT || 'sg-default-salt';
+
+function maskValue(value: string): string {
+  const hash = crypto.createHash('sha256').update(SALT + value).digest('hex');
+  const tail = value.slice(-2);
+  return `${hash}${tail}`;
+}
+
+export function maskEmail(email: string): string {
+  return maskValue(email);
+}
+
+export function maskPhone(phone: string): string {
+  return maskValue(phone);
+}
+
+export function maskSSN(ssn: string): string {
+  return maskValue(ssn);
+}
+
+export function maskName(name: string): string {
+  return maskValue(name);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-next": "14.2.3",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5.5.3",
         "vitest": "^1.6.0"
       }
@@ -46,6 +47,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1279,6 +1304,34 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -2596,6 +2649,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2772,6 +2832,16 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5012,6 +5082,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7121,6 +7198,57 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -7390,6 +7518,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7808,6 +7943,16 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "vitest run tests/unit",
     "test:e2e": "npm run build && playwright test",
-    "build:ext": "tsc -p extension/tsconfig.json"
+    "build:ext": "tsc -p extension/tsconfig.json",
+    "retention": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/retention.ts"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -36,6 +37,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/scripts/retention.ts
+++ b/scripts/retention.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { writeAudit } from '../lib/audit/logger';
+
+async function main() {
+  const days = parseInt(process.env.TELEMETRY_RETENTION_DAYS || '30', 10);
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const dir = path.join(process.cwd(), '.data', 'telemetry');
+  const file = path.join(dir, 'events.ndjson');
+  let content: string;
+  try {
+    content = await fs.readFile(file, 'utf-8');
+  } catch {
+    console.log('no telemetry data');
+    return;
+  }
+  const lines = content.split('\n').filter(Boolean);
+  const keep: string[] = [];
+  const reqId = crypto.randomUUID();
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line);
+      if (event.ts < cutoff) {
+        await writeAudit({ action: 'delete', requestId: reqId, timestamp: Date.now(), record: event });
+      } else {
+        keep.push(line);
+      }
+    } catch {
+      keep.push(line);
+    }
+  }
+  await fs.writeFile(file, keep.join('\n') + (keep.length ? '\n' : ''));
+}
+
+main();

--- a/tests/unit/mask.test.ts
+++ b/tests/unit/mask.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { maskEmail, maskPhone, maskSSN, maskName } from '../../lib/privacy/mask';
+
+describe('mask', () => {
+  it('masks email deterministically', () => {
+    const a = maskEmail('user@example.com');
+    const b = maskEmail('user@example.com');
+    expect(a).toBe(b);
+    expect(a.endsWith('om')).toBe(true);
+  });
+
+  it('masks phone deterministically', () => {
+    const a = maskPhone('123-456-7890');
+    const b = maskPhone('123-456-7890');
+    expect(a).toBe(b);
+    expect(a.endsWith('90')).toBe(true);
+  });
+
+  it('masks ssn deterministically', () => {
+    const a = maskSSN('111-22-3333');
+    const b = maskSSN('111-22-3333');
+    expect(a).toBe(b);
+    expect(a.endsWith('33')).toBe(true);
+  });
+
+  it('masks name deterministically', () => {
+    const a = maskName('Alice');
+    const b = maskName('Alice');
+    expect(a).toBe(b);
+    expect(a.endsWith('ce')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- mask emails, phones, SSNs and names before telemetry is persisted
- add retention script with audit logging and document privacy controls

## Testing
- `npm test`
- `npm run retention`

------
https://chatgpt.com/codex/tasks/task_e_68b247890bdc8323b1c8d17e1424cd5e