### PR TITLE
fix: attach telemetry api key header

### DIFF
--- a/lib/telemetry/client.ts
+++ b/lib/telemetry/client.ts
@@ -20,9 +20,14 @@ function writeBuffer(events: TelemetryEvent[]) {
 }
 
 async function send(ev: TelemetryEvent) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = process.env.NEXT_PUBLIC_TELEMETRY_API_KEY;
+  if (apiKey) {
+    headers['x-api-key'] = apiKey;
+  }
   await fetch('/api/telemetry2', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(ev),
   });
 }


### PR DESCRIPTION
## Summary
- send x-api-key header from telemetry client when NEXT_PUBLIC_TELEMETRY_API_KEY is set
- test API key handling in telemetry client and route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b24aaa14d48323b3d7de471b898daa