### PR TITLE
docs: add usage budget controls

### DIFF
--- a/docs/USAGE_BUDGET.md
+++ b/docs/USAGE_BUDGET.md
@@ -1,0 +1,19 @@
+# Usage Budgets
+
+The system places explicit limits on how much content a crawl and analysis can consume. These budgets help keep costs predictable and prevent runaway runs.
+
+## Page Budget
+
+- **Purpose:** Caps how many pages the URL Scout and Content Miner will process.
+- **Default:** 100 pages.
+- **Configure:** set `PAGE_BUDGET` in the environment to override the default.
+- **Behavior:** once the limit is reached, additional pages are skipped and later agents operate only on the collected subset.
+
+## Token Budget
+
+- **Purpose:** Limits the number of LLM tokens the Strategy Builder may spend generating the market‑research blueprint.
+- **Default:** 100k tokens per run.
+- **Configure:** set `TOKEN_BUDGET` in the environment to control spending.
+- **Behavior:** when the budget is exhausted, remaining sections are truncated or omitted to avoid exceeding cost thresholds.
+
+Adjust these budgets to balance depth versus cost. Lower numbers give faster, cheaper runs; higher numbers allow broader coverage and richer analysis.


### PR DESCRIPTION
## Summary
- document how page and token budgets constrain crawls and LLM usage

## Testing
- `npm run lint` *(fails: Invalid package.json parse error)*
- `npm run format:check` *(fails: Invalid package.json parse error)*
- `npm run env:check` *(fails: Invalid package.json parse error)*
- `npm test` *(fails: Invalid package.json parse error)*
- `npm run test:e2e` *(fails: Invalid package.json parse error)*
- `gitleaks detect --no-git`


------
https://chatgpt.com/codex/tasks/task_e_68b24fc329a8832396b502daa95010bf