### PR TITLE
test: ensure crawler respects page limit

### DIFF
--- a/lib/crawler.ts
+++ b/lib/crawler.ts
@@ -1,0 +1,34 @@
+export interface Page {
+  url: string;
+  links: string[];
+}
+
+export type FetchPage = (url: string) => Promise<Page> | Page;
+
+/**
+ * Crawl starting from `startUrl` using provided `fetchPage` callback.
+ * The crawler stops when `pageLimit` pages have been visited.
+ */
+export async function crawl(
+  startUrl: string,
+  fetchPage: FetchPage,
+  pageLimit: number
+): Promise<Page[]> {
+  const visited = new Set<string>();
+  const result: Page[] = [];
+  const queue: string[] = [startUrl];
+
+  while (queue.length > 0 && visited.size < pageLimit) {
+    const url = queue.shift()!;
+    if (visited.has(url)) continue;
+    const page = await fetchPage(url);
+    visited.add(url);
+    result.push(page);
+    for (const link of page.links) {
+      if (!visited.has(link)) {
+        queue.push(link);
+      }
+    }
+  }
+  return result;
+}

--- a/tests/unit/crawler.test.ts
+++ b/tests/unit/crawler.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { crawl, FetchPage, Page } from '../../lib/crawler';
+
+describe('crawler', () => {
+  it('stops when page count exceeds limit', async () => {
+    const fetchHistory: string[] = [];
+    const fetchPage: FetchPage = async (url: string): Promise<Page> => {
+      fetchHistory.push(url);
+      const id = Number(url.replace('page', ''));
+      return { url, links: [`page${id + 1}`] };
+    };
+
+    const pages = await crawl('page1', fetchPage, 3);
+
+    expect(pages.map((p) => p.url)).toEqual(['page1', 'page2', 'page3']);
+    expect(fetchHistory).toEqual(['page1', 'page2', 'page3']);
+  });
+});


### PR DESCRIPTION
## Summary
- add minimal BFS crawler helper with page limit
- test crawler halts once max pages reached

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24fb7a89483238a28ee117eac4106