### PR TITLE
feat: add cost logger for token budget

### DIFF
--- a/lib/telemetry/costLogger.ts
+++ b/lib/telemetry/costLogger.ts
@@ -1,0 +1,17 @@
+export function createCostLogger(budget: number) {
+  let spent = 0;
+  let warned = false;
+
+  return function log(tokens: number) {
+    spent += tokens;
+    const ratio = spent / budget;
+    const percent = (ratio * 100).toFixed(1);
+
+    if (!warned && ratio >= 0.8) {
+      warned = true;
+      console.warn(`Token spend at ${percent}% of budget (${spent}/${budget})`);
+    } else {
+      console.log(`Token spend: ${spent}/${budget} (${percent}%)`);
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.5.3",
     "prettier": "^3.3.3",
     "eslint-config-prettier": "^9.1.0",
-    "tsx": "^4.7.0"
+    "tsx": "^4.7.0",
     "ts-node": "^10.9.2"
   }
 }

--- a/tests/unit/costLogger.test.ts
+++ b/tests/unit/costLogger.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createCostLogger } from '../../lib/telemetry/costLogger';
+
+describe('cost logger', () => {
+  it('warns when spend reaches 80% of budget', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logger = createCostLogger(100);
+
+    logger(50);
+    expect(warn).not.toHaveBeenCalled();
+
+    logger(30);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    logger(10);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    warn.mockRestore();
+    log.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add utility to log token spend and warn when 80% budget reached
- add unit test covering cost logger behavior
- fix package.json syntax to allow dependency parsing

## Testing
- `npm test` *(fails: multiple exports in lib/env.ts and malformed imports in app/api/telemetry/route.ts)*
- `npm run lint` *(fails: parsing error in app/api/telemetry/route.ts)*
- `npm run format:check` *(fails: package-lock.json syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b24fab1dd883239bd610c22a4952ef