### PR TITLE
feat: add page limit to crawler

### DIFF
--- a/lib/url-scout.ts
+++ b/lib/url-scout.ts
@@ -1,0 +1,73 @@
+import crypto from 'node:crypto';
+
+export interface CrawlConfig {
+  baseUrl: string;
+  maxDepth: number;
+  maxPages?: number;
+  fetchFn?: (url: string) => Promise<string>;
+}
+
+export interface CrawlResult {
+  crawlId: string;
+  discoveredUrls: string[];
+  total: number;
+}
+
+export class PageLimitExceededError extends Error {
+  constructor(limit: number) {
+    super(`Page limit exceeded: ${limit}`);
+    this.name = 'PageLimitExceededError';
+  }
+}
+
+async function defaultFetch(url: string): Promise<string> {
+  const res = await fetch(url);
+  return res.text();
+}
+
+function extractLinks(html: string, origin: string): string[] {
+  const links: string[] = [];
+  const hrefRegex = /href="(.*?)"/g;
+  for (const match of html.matchAll(hrefRegex)) {
+    try {
+      const href = match[1];
+      const url = new URL(href, origin);
+      if (url.origin === origin) {
+        links.push(url.href);
+      }
+    } catch {
+      // ignore invalid urls
+    }
+  }
+  return links;
+}
+
+export async function crawl(config: CrawlConfig): Promise<CrawlResult> {
+  const { baseUrl, maxDepth, maxPages = Infinity, fetchFn = defaultFetch } = config;
+  const origin = new URL(baseUrl).origin;
+  const queue: { url: string; depth: number }[] = [{ url: baseUrl, depth: 0 }];
+  const visited = new Set<string>();
+
+  while (queue.length) {
+    const { url, depth } = queue.shift()!;
+    if (visited.has(url)) continue;
+    visited.add(url);
+    if (visited.size > maxPages) {
+      throw new PageLimitExceededError(maxPages);
+    }
+    if (depth >= maxDepth) continue;
+    const html = await fetchFn(url);
+    const links = extractLinks(html, origin);
+    for (const link of links) {
+      if (!visited.has(link)) {
+        queue.push({ url: link, depth: depth + 1 });
+      }
+    }
+  }
+
+  return {
+    crawlId: crypto.randomUUID(),
+    discoveredUrls: Array.from(visited),
+    total: visited.size,
+  };
+}

--- a/tests/unit/urlScout.test.ts
+++ b/tests/unit/urlScout.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { crawl, PageLimitExceededError } from '../../lib/url-scout';
+
+describe('url-scout page limit', () => {
+  const pages: Record<string, string> = {
+    'https://example.com/': '<a href="/a"></a><a href="/b"></a>',
+    'https://example.com/a': '<a href="/c"></a>',
+    'https://example.com/b': '',
+    'https://example.com/c': '',
+  };
+  const fetcher = async (url: string) => pages[url] ?? '';
+
+  it('aborts when page limit exceeded', async () => {
+    await expect(
+      crawl({ baseUrl: 'https://example.com/', maxDepth: 3, maxPages: 3, fetchFn: fetcher })
+    ).rejects.toBeInstanceOf(PageLimitExceededError);
+  });
+
+  it('returns results up to page limit', async () => {
+    const res = await crawl({
+      baseUrl: 'https://example.com/',
+      maxDepth: 3,
+      maxPages: 4,
+      fetchFn: fetcher,
+    });
+    expect(res.total).toBe(4);
+    expect(res.discoveredUrls).toContain('https://example.com/c');
+  });
+});


### PR DESCRIPTION
## Summary
- add optional `maxPages` setting for URL crawler
- stop crawling with `PageLimitExceededError` once limit is reached
- cover page-limit behavior with unit tests

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*
- `npx eslint lib/url-scout.ts tests/unit/urlScout.test.ts` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f9712b48323a918e647229769a6