### PR TITLE
feat: add weekly token cost report

### DIFF
--- a/.github/workflows/cost-report.yml
+++ b/.github/workflows/cost-report.yml
@@ -1,0 +1,20 @@
+name: Weekly Cost Report
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  cost-report:
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm run cost-report

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "DB_DRIVER=memory vitest run tests/unit tests/api",
     "test:e2e": "npm run build && playwright test",
     "build:ext": "tsc -p extension/tsconfig.json",
-    "retention": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/retention.ts"
+    "retention": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/retention.ts",
+    "cost-report": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/cost-report.ts"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -45,7 +46,7 @@
     "typescript": "^5.5.3",
     "prettier": "^3.3.3",
     "eslint-config-prettier": "^9.1.0",
-    "tsx": "^4.7.0"
+    "tsx": "^4.7.0",
     "ts-node": "^10.9.2"
   }
 }

--- a/scripts/cost-report.ts
+++ b/scripts/cost-report.ts
@@ -1,0 +1,36 @@
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) {
+  console.error('Missing OPENAI_API_KEY');
+  process.exit(1);
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+const end = new Date();
+const start = new Date();
+start.setDate(end.getDate() - 7);
+
+const url = `https://api.openai.com/v1/usage?start_date=${formatDate(start)}&end_date=${formatDate(end)}`;
+
+const res = await fetch(url, {
+  headers: {
+    Authorization: `Bearer ${apiKey}`,
+  },
+});
+
+if (!res.ok) {
+  console.error('Failed to fetch usage', res.status, res.statusText);
+  process.exit(1);
+}
+
+const data = await res.json();
+const entries = Array.isArray(data.data) ? data.data : [];
+const tokens = entries.reduce(
+  (sum: number, d: any) =>
+    sum + (d.n_context_tokens_total ?? 0) + (d.n_generated_tokens_total ?? 0),
+  0,
+);
+
+console.log(`Weekly token spend: ${tokens}`);


### PR DESCRIPTION
## Summary
- add cost-report script to fetch last week's token usage
- run cost report weekly via scheduled GitHub Action
- expose `npm run cost-report` for manual reporting

## Testing
- `npm run lint` *(fails: Parsing error in app/api/telemetry/route.ts)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b24fb132f883238583feee8fc59c47