### PR TITLE
feat: add blueprint citation lint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,15 @@
+const requireCitationRule = require('./eslint-rules/require-citation-in-blueprint');
+
 module.exports = {
   extends: ['next/core-web-vitals', 'prettier'],
+  plugins: {
+    blueprint: {
+      rules: {
+        'require-citation': requireCitationRule,
+      },
+    },
+  },
+  rules: {
+    'blueprint/require-citation': 'warn',
+  },
 };

--- a/eslint-rules/require-citation-in-blueprint.js
+++ b/eslint-rules/require-citation-in-blueprint.js
@@ -1,0 +1,44 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require citation field in blueprint objects',
+      recommended: false,
+    },
+    schema: [],
+  },
+  create(context) {
+    function isBlueprintProperty(node) {
+      if (!node) return false;
+      if (node.type === 'Property') {
+        const key = node.key;
+        if (key.type === 'Identifier' && key.name === 'blueprint') return true;
+        if (key.type === 'Literal' && key.value === 'blueprint') return true;
+      }
+      if (node.type === 'VariableDeclarator') {
+        const id = node.id;
+        if (id.type === 'Identifier' && id.name === 'blueprint') return true;
+      }
+      return false;
+    }
+
+    return {
+      ObjectExpression(node) {
+        const parent = node.parent;
+        if (!isBlueprintProperty(parent)) return;
+        const hasCitation = node.properties.some(
+          (prop) =>
+            prop.type === 'Property' &&
+            ((prop.key.type === 'Identifier' && prop.key.name === 'citation') ||
+              (prop.key.type === 'Literal' && prop.key.value === 'citation'))
+        );
+        if (!hasCitation) {
+          context.report({
+            node,
+            message: 'Blueprint object should include a "citation" field.',
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- warn when blueprint objects omit a citation field
- enable custom blueprint lint rule in ESLint config

## Testing
- `npm run lint` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f903128832393e5633d9856bbc2