### PR TITLE
Log blueprint approvals to audit logger

### DIFF
--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 
 export interface AuditEntry {
-  action: 'create' | 'delete';
+  action: 'create' | 'delete' | 'approve';
   requestId: string;
   timestamp: number;
   record: any;

--- a/lib/blueprint.ts
+++ b/lib/blueprint.ts
@@ -1,0 +1,13 @@
+import crypto from 'crypto';
+import { writeAudit } from './audit/logger';
+
+export interface BlueprintApproval {
+  blueprintId: string;
+  approvedBy: string;
+}
+
+export async function approveBlueprint(blueprintId: string, approvedBy: string): Promise<void> {
+  const record: BlueprintApproval = { blueprintId, approvedBy };
+  const requestId = crypto.randomUUID();
+  await writeAudit({ action: 'approve', requestId, timestamp: Date.now(), record });
+}

--- a/tests/unit/blueprint.audit.test.ts
+++ b/tests/unit/blueprint.audit.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../lib/audit/logger', () => ({ writeAudit: vi.fn() }));
+
+import { approveBlueprint } from '../../lib/blueprint';
+import { writeAudit } from '../../lib/audit/logger';
+
+describe('approveBlueprint', () => {
+  it('writes approval to audit log', async () => {
+    await approveBlueprint('bp-1', 'alice');
+    expect(writeAudit).toHaveBeenCalledTimes(1);
+    const entry = (writeAudit as any).mock.calls[0][0];
+    expect(entry.action).toBe('approve');
+    expect(entry.record).toEqual({ blueprintId: 'bp-1', approvedBy: 'alice' });
+  });
+});


### PR DESCRIPTION
## Summary
- allow audit logger to accept `approve` events
- add `approveBlueprint` helper that records approvals to audit log
- cover blueprint approval logging with unit test

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f7da3388323b0969895030a7ec0