### PR TITLE
feat: add blueprint approval toggle

### DIFF
--- a/app/(console)/blueprint/page.tsx
+++ b/app/(console)/blueprint/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useBlueprint } from '@/store/useBlueprint';
+
+export default function BlueprintPage() {
+  const { approved, toggleApproval } = useBlueprint();
+
+  return (
+    <section className="p-8 space-y-6">
+      <h1 className="text-3xl font-bold">Blueprint Approval</h1>
+      <div className="flex items-center gap-4">
+        <span className="font-medium">Status: {approved ? 'Approved' : 'Pending'}</span>
+        <button
+          onClick={toggleApproval}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded"
+        >
+          {approved ? 'Revoke' : 'Approve'}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/store/useBlueprint.ts
+++ b/store/useBlueprint.ts
@@ -1,0 +1,12 @@
+'use client';
+import { create } from 'zustand';
+
+type BlueprintState = {
+  approved: boolean;
+  toggleApproval: () => void;
+};
+
+export const useBlueprint = create<BlueprintState>((set) => ({
+  approved: false,
+  toggleApproval: () => set((s) => ({ approved: !s.approved })),
+}));


### PR DESCRIPTION
## Summary
- add zustand store to manage blueprint approval state
- introduce admin console page to toggle blueprint approval

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f77b3cc83238d347587ecf76bb4