### PR TITLE
feat: guard service role key on client

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -10,6 +10,10 @@ const envSchema = z.object({
   LEAD_WEBHOOK_URL: z.string().url().optional(),
 });
 
+if (typeof window !== 'undefined' && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY should not be exposed to the client');
+}
+
 const parsed = envSchema.safeParse(process.env);
 
 if (!parsed.success) {


### PR DESCRIPTION
## Summary
- throw if `SUPABASE_SERVICE_ROLE_KEY` appears in a browser environment

## Testing
- `node_modules/.bin/next lint` *(fails: EJSONPARSE in package.json)*
- `DB_DRIVER=memory node_modules/.bin/vitest run tests/unit tests/api` *(fails: Failed to load PostCSS config - SyntaxError: Expected ',' or '}' after property value in JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68b24ef14d64832391ec8c7cd6366228