### PR TITLE
Require lead approval before delivery

### DIFF
--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -6,6 +6,9 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const lead = LeadSchema.parse(body);
+    if (!lead.approved) {
+      return NextResponse.json({ error: 'Lead not approved' }, { status: 403 });
+    }
     await db.insertLead(lead);
     return NextResponse.json({ success: true }, { status: 201 });
   } catch (error) {

--- a/components/leads/LeadModal.tsx
+++ b/components/leads/LeadModal.tsx
@@ -28,7 +28,7 @@ export default function LeadModal() {
     const res = await fetch('/api/leads', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+      body: JSON.stringify({ ...data, approved: true }),
     });
     if (res.ok) {
       setSubmitted(true);

--- a/lib/db/drivers/sqlite.ts
+++ b/lib/db/drivers/sqlite.ts
@@ -11,7 +11,7 @@ export function createSqliteAdapter(url: string): DBAdapter {
   const db = new Database(file);
 
   db.prepare(
-    'CREATE TABLE IF NOT EXISTS leads (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT, company TEXT, size TEXT, vertical TEXT)'
+    'CREATE TABLE IF NOT EXISTS leads (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT, company TEXT, size TEXT, vertical TEXT, approved INTEGER DEFAULT 0)'
   ).run();
   db.prepare(
     'CREATE TABLE IF NOT EXISTS telemetry (id INTEGER PRIMARY KEY AUTOINCREMENT, event TEXT, props TEXT, ts INTEGER)'
@@ -21,8 +21,14 @@ export function createSqliteAdapter(url: string): DBAdapter {
     async insertLead(lead) {
       const parsed = LeadSchema.parse(lead);
       db.prepare(
-        'INSERT INTO leads (email, company, size, vertical) VALUES (?, ?, ?, ?)'
-      ).run(parsed.email, parsed.company, parsed.size, parsed.vertical);
+        'INSERT INTO leads (email, company, size, vertical, approved) VALUES (?, ?, ?, ?, ?)'
+      ).run(
+        parsed.email,
+        parsed.company,
+        parsed.size,
+        parsed.vertical,
+        parsed.approved ? 1 : 0
+      );
     },
     async insertTelemetry(event) {
       const parsed = TelemetryEventSchema.parse(event);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.5.3",
     "prettier": "^3.3.3",
     "eslint-config-prettier": "^9.1.0",
-    "tsx": "^4.7.0"
+    "tsx": "^4.7.0",
     "ts-node": "^10.9.2"
   }
 }

--- a/schemas/lead.ts
+++ b/schemas/lead.ts
@@ -5,6 +5,7 @@ export const LeadSchema = z.object({
   company: z.string().min(1),
   size: z.string().min(1),
   vertical: z.string().min(1),
+  approved: z.boolean().default(false),
 });
 
 export type Lead = z.infer<typeof LeadSchema>;

--- a/tests/api/leads.insert.test.ts
+++ b/tests/api/leads.insert.test.ts
@@ -26,11 +26,28 @@ describe('leads route', () => {
         company: 'Acme',
         size: '10',
         vertical: 'tech',
+        approved: true,
       }),
     });
     const res = await POST(req);
     expect(res.status).toBe(201);
     expect((db as any).leads.length).toBe(1);
+  });
+
+  it('rejects unapproved lead', async () => {
+    const req = new Request('http://localhost/api/leads', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'b@example.com',
+        company: 'Beta',
+        size: '20',
+        vertical: 'finance',
+        approved: false,
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    expect((db as any).leads.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- add `approved` flag to `Lead` schema and SQLite storage
- reject lead submissions unless `approved` is true
- ensure lead modal sends approval signal and add tests
- fix package.json JSON syntax

## Testing
- `DB_DRIVER=memory npx --yes vitest run tests/unit tests/api` *(fails: Multiple exports with the same name "env"; unexpected `{` in telemetry route)*
- `npm run lint` *(fails: Parsing error in app/api/telemetry/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f71a0f4832380d8bf9d3324734d