### PR TITLE
test: ensure env config hides service role key

### DIFF
--- a/tests/unit/env-config.test.ts
+++ b/tests/unit/env-config.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+describe('env config', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.PUBLIC_SITE_URL = 'https://example.com';
+    process.env.VITE_SUPABASE_URL = 'https://db.example.com';
+    process.env.VITE_SUPABASE_ANON_KEY = 'anon';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'secret';
+    process.env.VITE_SCRAPER_API_BASE_URL = 'https://scraper.example.com';
+    process.env.OPENAI_API_KEY = 'openai';
+    process.env.DB_DRIVER = 'memory';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('does not expose service role key', async () => {
+    const { env } = await import('../../lib/env');
+    expect(process.env.SUPABASE_SERVICE_ROLE_KEY).toBe('secret');
+    expect('SUPABASE_SERVICE_ROLE_KEY' in env).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit test ensuring the env config object never includes SUPABASE_SERVICE_ROLE_KEY

## Testing
- `DB_DRIVER=memory PUBLIC_SITE_URL=https://a.com VITE_SUPABASE_URL=https://supabase.io VITE_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service VITE_SCRAPER_API_BASE_URL=https://scraper.io OPENAI_API_KEY=key node_modules/.bin/vitest run tests/unit/env-config.test.ts` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f0c2d0c8323b01b2d8fe4c8758c