### PR TITLE
Add approval gate for blueprint

### DIFF
--- a/app/api/mock/[resource]/route.ts
+++ b/app/api/mock/[resource]/route.ts
@@ -3,13 +3,25 @@ import incidents from '@/data/incidents.json';
 import policies from '@/data/policies.json';
 import approvals from '@/data/approvals.json';
 import pricing from '@/data/pricing.json';
+import blueprint from '@/data/blueprint.json';
 
 export async function GET(
   request: Request,
   { params }: { params: { resource: string } }
 ) {
-  const map: Record<string, any> = { incidents, policies, approvals, pricing };
+  const map: Record<string, any> = { incidents, policies, approvals, pricing, blueprint };
   const data = map[params.resource] || [];
   await new Promise((res) => setTimeout(res, 200));
+
+  if (params.resource === 'blueprint') {
+    if (!data.approved) {
+      return NextResponse.json(
+        { error: 'Blueprint pending manual approval' },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(data.blueprint);
+  }
+
   return NextResponse.json(data);
 }

--- a/data/blueprint.json
+++ b/data/blueprint.json
@@ -1,0 +1,16 @@
+{
+  "approved": false,
+  "analysisId": "demo",
+  "blueprint": {
+    "companyOverview": "This is a mock blueprint pending approval.",
+    "keyOfferings": [],
+    "targetSegments": [],
+    "marketTrends": [],
+    "competitiveLandscape": [],
+    "opportunitiesForAI": [],
+    "techStack": [],
+    "dataRisks": [],
+    "actionPlan": [],
+    "teamAIReadiness": ""
+  }
+}

--- a/tests/api/blueprint.approval.test.ts
+++ b/tests/api/blueprint.approval.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../../app/api/mock/[resource]/route';
+
+describe('blueprint approval', () => {
+  it('blocks unapproved blueprint access', async () => {
+    const req = new Request('http://localhost/api/mock/blueprint');
+    const res = await GET(req, { params: { resource: 'blueprint' } });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add mock blueprint data with approval flag
- block blueprint access via mock API unless approved
- test that blueprint route rejects unapproved requests

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx eslint .` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f6be6ac832383ca15f19493198d