### PR TITLE
feat: warn when audit record depth exceeds limit

### DIFF
--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -8,10 +8,24 @@ export interface AuditEntry {
   record: any;
 }
 
+function getDepth(value: any, depth = 0): number {
+  if (value && typeof value === 'object') {
+    return Object.values(value).reduce(
+      (max, v) => Math.max(max, getDepth(v, depth + 1)),
+      depth + 1
+    );
+  }
+  return depth;
+}
+
 export async function writeAudit(entry: AuditEntry): Promise<void> {
   const dir = path.join(process.cwd(), '.logs');
   await fs.mkdir(dir, { recursive: true });
   const date = new Date().toISOString().slice(0, 10);
   const file = path.join(dir, `audit-${date}.jsonl`);
+  const depth = getDepth(entry.record);
+  if (depth > 2) {
+    console.warn(`audit record depth ${depth} exceeds 2`);
+  }
   await fs.appendFile(file, JSON.stringify(entry) + '\n');
 }

--- a/tests/unit/auditLogger.test.ts
+++ b/tests/unit/auditLogger.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { writeAudit } from '../../lib/audit/logger';
+import { rm } from 'fs/promises';
+import path from 'path';
+
+describe('writeAudit depth warning', () => {
+  it('warns when record depth exceeds 2', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const entry = {
+      action: 'create',
+      requestId: 'req1',
+      timestamp: Date.now(),
+      record: { a: { b: { c: 1 } } },
+    };
+    await writeAudit(entry);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    await rm(path.join(process.cwd(), '.logs'), { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- warn if audit record depth exceeds 2 for easier debugging
- add unit test covering audit depth warning

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f3e8d3c8323bfa6af0478b4f49b